### PR TITLE
v0.2.6: tighten adventurer prompts for 4.7 literalness

### DIFF
--- a/docs/superpowers/plans/2026-04-23-guildhall-v0.2.6-prompt-tightening.md
+++ b/docs/superpowers/plans/2026-04-23-guildhall-v0.2.6-prompt-tightening.md
@@ -1,0 +1,443 @@
+# Guildhall v0.2.6 — prompt tightening for 4.7 literalness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Guildhall v0.2.6 — add a standardized `## Your contract` block to each of the six existing adventurer prompts (INPUT / OUTPUT / NON-GOALS / EFFORT), fix the two wording nits surfaced by the v0.2.4 code-quality review on `model-echo`, update the design spec's Risks section with a one-line un-pause note, and bump the plugin version to 0.2.6.
+
+**Architecture:** Ten edits across eight files in a single commit on branch `ship/v0.2.6-prompt-tightening`. No new files. No new agents. Prompt hygiene only — the observable behavior of `/quest` is unchanged; the contract blocks make the agent expectations explicit so Opus 4.7's literal interpretation has the structured hooks to latch onto.
+
+**Tech Stack:** Markdown (agent bodies). No code. Verification is structural (grep for the new heading in each file) plus a final cross-check that no prose outside the new blocks drifted.
+
+**This is rung 3 of the 5-rung staircase in `docs/superpowers/specs/2026-04-23-guildhall-v0.3-design.md` (v0.2.3 → v0.2.4 → v0.2.5 → v0.2.6 → v0.3.0).**
+
+**Why we're proceeding despite the paused routing bug:** roster value and prompt clarity are independent of model-tier routing. Tighter prompts help Opus 4.7 follow the contract literally regardless of tier. The cost-posture payoff activates when the upstream fix lands; everything in this rung is valuable today at any tier.
+
+---
+
+## Context for the engineer (zero-assumption briefing)
+
+**Repo state at plan-write time:**
+- Working on branch `ship/v0.2.6-prompt-tightening`, cut from `main` at commit `dccaa60` (the merge commit from PR #1).
+- Six existing adventurer files live at `plugin/agents/<name>.md`. Each has YAML frontmatter, a character quote, then an opening "You are **Name** —" paragraph, then agent-specific body prose.
+- `plugin/agents/model-echo.md` is the v0.2.4 diagnostic — also gets two small edits.
+- `plugin/.claude-plugin/plugin.json` is at version `0.2.5`; bumps to `0.2.6` in this rung.
+- `docs/superpowers/specs/2026-04-23-guildhall-v0.3-design.md` has a "Risks and mitigations" section that currently treats the paused staircase as terminal; a one-line addendum is added.
+
+**Why the contract block pattern:** Opus 4.7 interprets prompts literally and does not fill in gaps. An explicit INPUT / OUTPUT / NON-GOALS / EFFORT block gives the model fixed hooks: what does it receive, what must it produce, what must it refuse, and at what effort level. The design spec Section 4 defines the target contract for each agent; this plan is the execution of that section for the six existing adventurers.
+
+**Where the contract block is inserted in each file:**
+
+Immediately after the opening "You are **<Name>** — ..." paragraph, with a blank line above and below. In some agents, the opening paragraph is followed by a list (e.g., prototype-builder's "Your ceremony is ZERO"). The new section is inserted between the paragraph and that list, leaving existing content intact.
+
+---
+
+## File inventory
+
+Eight files change in this plan:
+
+- **Modify:** `plugin/agents/prototype-builder.md` (insert `## Your contract` block)
+- **Modify:** `plugin/agents/test-author.md` (insert `## Your contract` block)
+- **Modify:** `plugin/agents/feature-implementer.md` (insert `## Your contract` block)
+- **Modify:** `plugin/agents/refactorer.md` (insert `## Your contract` block)
+- **Modify:** `plugin/agents/debug-investigator.md` (insert `## Your contract` block)
+- **Modify:** `plugin/agents/ui-test-author.md` (insert `## Your contract` block)
+- **Modify:** `plugin/agents/model-echo.md` (two wording nits)
+- **Modify:** `docs/superpowers/specs/2026-04-23-guildhall-v0.3-design.md` (Risks addendum)
+- **Modify:** `plugin/.claude-plugin/plugin.json` (version bump)
+
+No new files. CHARACTERS.md untouched. README.md untouched. Single commit.
+
+---
+
+## Task 1: Add `## Your contract` block to each of the six existing adventurers
+
+**Shared insertion rule:** for each of the six agent files, locate the opening paragraph that begins `You are **<Name>** —`. The next non-empty line should either be a list, a heading, or another paragraph. Insert the new `## Your contract` section with a blank line before and after, BETWEEN the opening paragraph and that next block, preserving all existing content exactly.
+
+### - [ ] Step 1.1: prototype-builder.md
+
+**File:** `plugin/agents/prototype-builder.md`
+
+Read the file to find the exact opening paragraph text, then use Edit with:
+
+- **old_string:** the opening paragraph line (`You are **Pip Quickfoot** — a halfling scout who returns from every expedition with a working thing and a crooked grin. Your ONLY job: get a working spike in front of Jason as fast as possible.`) followed by the blank line and the exact next non-empty line (whichever it is — a heading, a bulleted item, etc.).
+
+- **new_string:** the same opening paragraph, followed by the new contract block, followed by the same next line preserved exactly. The new block:
+
+```markdown
+## Your contract
+
+- **INPUT:** a one-line ask from Mordain plus (where relevant) cited repo conventions — language choice, existing framework, running-environment notes.
+- **OUTPUT:** working code in the repo (new file or edit), plus a one-line "works / doesn't" status report back to Mordain. No tests, no README, no polish.
+- **NON-GOALS:** do NOT write tests, do NOT handle errors you have not actually seen happen, do NOT design for cases the ask did not mention, do NOT refactor existing code beyond what the ask touches.
+- **EFFORT:** `medium` — speed over rigor. This is disposable code.
+```
+
+**Verify:** `grep -c '^## Your contract$' plugin/agents/prototype-builder.md` → `1`.
+
+### - [ ] Step 1.2: test-author.md
+
+**File:** `plugin/agents/test-author.md`
+
+Same pattern. Opening paragraph: `You are **Seraphine Dawnveil** — an elven Cleric who reads the IDD Spec as scripture. Your ONLY job: write tests that cover the Expectations block of the Spec, independently of any implementation.`
+
+**Contract block to insert:**
+
+```markdown
+## Your contract
+
+- **INPUT:** the path to an IDD Spec file. The Expectations block is load-bearing — every expectation maps to at least one test.
+- **OUTPUT:** one or more failing test files plus the list of file paths you wrote. Tests must fail against a blank implementation and pass against a correct one.
+- **NON-GOALS:** do NOT read any implementation code in `src/` / `lib/` / equivalent, do NOT run existing tests to confirm state, do NOT guess about ambiguous spec wording — if the spec is ambiguous, flag it and stop, do not invent a resolution.
+- **EFFORT:** `high` — strict spec-to-test mapping is the entire value.
+```
+
+**Verify:** `grep -c '^## Your contract$' plugin/agents/test-author.md` → `1`.
+
+### - [ ] Step 1.3: feature-implementer.md
+
+**File:** `plugin/agents/feature-implementer.md`
+
+Opening paragraph begins `You are **Bruga Ironseam**`. Read the file to get the exact opening sentence.
+
+**Contract block:**
+
+```markdown
+## Your contract
+
+- **INPUT:** an IDD Spec (Expectations and Boundaries blocks both load-bearing) plus the path(s) to the failing test file(s) produced by test-author.
+- **OUTPUT:** code that turns the failing tests green, plus the list of files you wrote or changed. No new tests written; tests in scope for you are READ ONLY.
+- **NON-GOALS:** do NOT modify test files, do NOT add features beyond the Expectations, do NOT stray outside the Boundaries block, do NOT refactor existing code unless refactoring is explicitly required to make tests pass. If the blueprint (spec) is malformed or self-contradicting, drop the hammer and return to Mordain.
+- **EFFORT:** `high` — structured work with a known success criterion (green tests).
+```
+
+**Verify:** `grep -c '^## Your contract$' plugin/agents/feature-implementer.md` → `1`.
+
+### - [ ] Step 1.4: refactorer.md
+
+**File:** `plugin/agents/refactorer.md`
+
+Opening paragraph begins `You are **Tink Whiffletree**`.
+
+**Contract block:**
+
+```markdown
+## Your contract
+
+- **INPUT:** a narrowly scoped instruction from Mordain ("extract X", "rename Y to Z") plus confirmation that the current test state is green.
+- **OUTPUT:** a behavior-preserving diff plus confirmation that tests are still green after your changes. If your refactor breaks any test, back out completely — every time, no exceptions.
+- **NON-GOALS:** do NOT broaden the scope by one line beyond what Mordain asked, do NOT "also clean up" unrelated code even if it is bothering you (mention in report; do not fix), do NOT change behavior — any behavior delta is a failed refactor.
+- **EFFORT:** `high` — mechanical but verification-sensitive.
+```
+
+**Verify:** `grep -c '^## Your contract$' plugin/agents/refactorer.md` → `1`.
+
+### - [ ] Step 1.5: debug-investigator.md
+
+**File:** `plugin/agents/debug-investigator.md`
+
+Opening paragraph begins `You are **Kael the Tracker**`.
+
+**Contract block:**
+
+```markdown
+## Your contract
+
+- **INPUT:** a bug reproduction (steps or code that triggers the issue), the error trace, and the relevant file paths Mordain has already surveyed.
+- **OUTPUT:** a written root-cause report naming the actual point of origin. If you cannot prove the cause, say "uncertain" explicitly and list what you ruled out.
+- **NON-GOALS:** do NOT propose a fix, do NOT edit any file, do NOT refactor "while you are here", do NOT speculate — claims must be traceable to evidence in the code or logs.
+- **EFFORT:** `xhigh` — root causes hide; open-ended investigation warrants the tokens.
+```
+
+**Verify:** `grep -c '^## Your contract$' plugin/agents/debug-investigator.md` → `1`.
+
+### - [ ] Step 1.6: ui-test-author.md
+
+**File:** `plugin/agents/ui-test-author.md`
+
+Opening paragraph begins `You are **Vera Nightwhistle**`.
+
+**Contract block:**
+
+```markdown
+## Your contract
+
+- **INPUT:** an IDD Spec (Expectations block load-bearing), a running-app URL, and the code paths for the feature being tested. You ARE permitted to read implementation code here — this is the exception to the test-authoring independence rule, because you cannot write selector-level tests against an interface you have not examined.
+- **OUTPUT:** Playwright test files plus selector notes explaining the decisions behind non-obvious locators.
+- **NON-GOALS:** do NOT modify implementation code, do NOT rewrite tests to match a botched performance — if an actor misses a cue, that is a bug in the UI, not your script; do NOT add unit tests (those are Seraphine's domain), do NOT spin up your own dev server — the running app URL is given to you.
+- **EFFORT:** `high` — structured work with a running reference.
+```
+
+**Verify:** `grep -c '^## Your contract$' plugin/agents/ui-test-author.md` → `1`.
+
+### - [ ] Step 1.7: Cross-check all six insertions
+
+Run:
+```bash
+grep -l '^## Your contract$' plugin/agents/*.md | sort
+```
+
+Expected output (exactly these 7 lines, in alpha order):
+```
+plugin/agents/debug-investigator.md
+plugin/agents/feature-implementer.md
+plugin/agents/model-echo.md
+plugin/agents/prototype-builder.md
+plugin/agents/refactorer.md
+plugin/agents/test-author.md
+plugin/agents/ui-test-author.md
+```
+
+(`model-echo.md` already had `## Your contract` from v0.2.4 — so the total is 7 files with the heading after Task 1 completes.)
+
+Then verify nothing else was corrupted — each of the six files should still have their frontmatter intact:
+```bash
+for f in plugin/agents/prototype-builder.md plugin/agents/test-author.md plugin/agents/feature-implementer.md plugin/agents/refactorer.md plugin/agents/debug-investigator.md plugin/agents/ui-test-author.md; do
+  head -1 "$f" | grep -q '^---$' && echo "OK $f" || echo "FAIL $f"
+done
+```
+
+Expected: six `OK` lines.
+
+---
+
+## Task 2: Fix the two model-echo wording nits
+
+**File:** `plugin/agents/model-echo.md`
+
+Both nits come from the v0.2.4 code-quality review.
+
+### - [ ] Step 2.1: Fix the INPUT contradiction
+
+The current contract says `INPUT: none (Mordain dispatches you with an empty prompt or a one-line greeting)`. But Mordain now passes the literal string `"Report the model you are running on."` — so "none" whiplashes. Reframe as a greeting.
+
+Use Edit on `plugin/agents/model-echo.md`:
+- **old_string:** `- **INPUT:** none (Mordain dispatches you with an empty prompt or a one-line greeting).`
+- **new_string:** `- **INPUT:** a one-line greeting from Mordain (e.g., "Report the model you are running on."). You do not need to parse it — your job is fixed regardless of the greeting text.`
+
+### - [ ] Step 2.2: Fix the "no other command" rule contradiction
+
+The Hard Rules block says `Do NOT run any command other than \`echo "$ANTHROPIC_MODEL"\``. But the "self-introspection" fallback doesn't run any command at all — so a strict reading forbids the fallback. Narrow the rule to Bash commands.
+
+Use Edit on `plugin/agents/model-echo.md`:
+- **old_string:** `- Do NOT run any command other than \`echo "$ANTHROPIC_MODEL"\`.`
+- **new_string:** `- Do NOT run any Bash command other than \`echo "$ANTHROPIC_MODEL"\`. (Self-introspection requires no command at all and remains allowed per the fallback above.)`
+
+### - [ ] Step 2.3: Verify
+
+Run:
+```bash
+grep -c 'one-line greeting from Mordain' plugin/agents/model-echo.md
+```
+Expected: `1`.
+
+Run:
+```bash
+grep -c 'any Bash command other than' plugin/agents/model-echo.md
+```
+Expected: `1`.
+
+---
+
+## Task 3: Update the design spec Risks section (un-pause addendum)
+
+**File:** `docs/superpowers/specs/2026-04-23-guildhall-v0.3-design.md`
+
+### - [ ] Step 3.1: Append the un-pause line to the first Risk item
+
+Read the file's "Risks and mitigations" section. The first Risk item currently reads (approximately):
+
+> - **Risk:** the self-check at v0.2.4 reveals alias frontmatter is broken too, not just full IDs. **Mitigation:** pause the staircase, open an upstream Claude Code issue, fall back to explicit `--model` in session as a workaround until fixed.
+
+Use Edit to append an un-pause addendum immediately after the mitigation sentence — insert `**Update (2026-04-23):** ...` text inline with the existing mitigation. Specifically:
+
+- **old_string:** `**Mitigation:** pause the staircase, open an upstream Claude Code issue, fall back to explicit `--model` in session as a workaround until fixed.`
+- **new_string:** `**Mitigation:** pause the staircase, open an upstream Claude Code issue, fall back to explicit `--model` in session as a workaround until fixed. **Update (2026-04-23):** dogfood run confirmed the bug and v0.2.5 documented the pause; staircase subsequently resumed at v0.2.6 on the reframe that roster value and prompt clarity are independent of model-tier routing — the cost posture activates latently when upstream ships a fix.`
+
+### - [ ] Step 3.2: Verify
+
+Run:
+```bash
+grep -c 'Update (2026-04-23)' docs/superpowers/specs/2026-04-23-guildhall-v0.3-design.md
+```
+Expected: `1`.
+
+---
+
+## Task 4: Bump version, stage, commit, verify
+
+### - [ ] Step 4.1: Bump plugin.json version
+
+Use Edit on `plugin/.claude-plugin/plugin.json`:
+- **old_string:** `"version": "0.2.5",`
+- **new_string:** `"version": "0.2.6",`
+
+### - [ ] Step 4.2: Verify the bump
+
+Run: `grep -n '"version"' plugin/.claude-plugin/plugin.json`
+Expected: `3:  "version": "0.2.6",`
+
+### - [ ] Step 4.3: Pre-commit tracked-file check
+
+Run: `git status --short`
+
+Expected tracked-file lines (exactly eight `M` entries, order-insensitive):
+```
+ M docs/superpowers/specs/2026-04-23-guildhall-v0.3-design.md
+ M plugin/.claude-plugin/plugin.json
+ M plugin/agents/debug-investigator.md
+ M plugin/agents/feature-implementer.md
+ M plugin/agents/model-echo.md
+ M plugin/agents/prototype-builder.md
+ M plugin/agents/refactorer.md
+ M plugin/agents/test-author.md
+ M plugin/agents/ui-test-author.md
+```
+
+Wait — that's nine files total (six adventurers + model-echo + design spec + plugin.json). Let me recount:
+
+1. plugin/agents/prototype-builder.md
+2. plugin/agents/test-author.md
+3. plugin/agents/feature-implementer.md
+4. plugin/agents/refactorer.md
+5. plugin/agents/debug-investigator.md
+6. plugin/agents/ui-test-author.md
+7. plugin/agents/model-echo.md
+8. docs/superpowers/specs/2026-04-23-guildhall-v0.3-design.md
+9. plugin/.claude-plugin/plugin.json
+
+Nine modified files total. Untracked `.claude/`, `CLAUDE.md`, `docs/superpowers/plans/2026-04-23-guildhall-v0.2.6-prompt-tightening.md`, `docs/superpowers/upstream-issue-draft.md`, and `plugin/.claude-plugin/marketplace.json` MAY appear and are acceptable — they are NOT staged in this commit.
+
+If any OTHER tracked file shows as modified (e.g., README, CHARACTERS.md), STOP and investigate.
+
+### - [ ] Step 4.4: Diff sanity-check — no prose drift outside the new blocks
+
+For the six adventurer edits, confirm the diff ADDS a `## Your contract` block and nothing else. Run:
+
+```bash
+git diff plugin/agents/prototype-builder.md | grep -cE '^\+'
+```
+Expected: 8 lines added (1 heading + 1 blank + 4 bullets + 1 blank + 1 trailing blank, approximately — accept 7 to 10).
+
+Repeat for each of the other five adventurer files and `model-echo.md`. If any file's addition count is vastly outside that range, the diff may have drifted — read the diff.
+
+Also spot-check that no line was REMOVED outside the model-echo edits:
+
+```bash
+for f in plugin/agents/prototype-builder.md plugin/agents/test-author.md plugin/agents/feature-implementer.md plugin/agents/refactorer.md plugin/agents/debug-investigator.md plugin/agents/ui-test-author.md; do
+  removed=$(git diff "$f" | grep -cE '^-[^-]' || echo 0)
+  echo "$f: $removed removed"
+done
+```
+
+Expected: `0 removed` for each of the six adventurers (they are pure additions). If any show non-zero removals, the Edit corrupted existing prose — STOP and investigate.
+
+`model-echo.md` will legitimately show 2 removed lines (the two nits being replaced).
+
+### - [ ] Step 4.5: Stage the nine files
+
+Run:
+```bash
+git add plugin/agents/prototype-builder.md plugin/agents/test-author.md plugin/agents/feature-implementer.md plugin/agents/refactorer.md plugin/agents/debug-investigator.md plugin/agents/ui-test-author.md plugin/agents/model-echo.md docs/superpowers/specs/2026-04-23-guildhall-v0.3-design.md plugin/.claude-plugin/plugin.json
+```
+
+Do NOT use `git add -A` or `git add .`.
+
+### - [ ] Step 4.6: Verify staging
+
+Run: `git diff --cached --stat`
+
+Expected: 9 files changed. All existing files (no new files).
+
+### - [ ] Step 4.7: Commit
+
+Use this HEREDOC:
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: tighten adventurer prompts for 4.7 literalness (v0.2.6)
+
+Adds an explicit `## Your contract` block (INPUT / OUTPUT / NON-GOALS /
+EFFORT) to each of the six existing adventurer prompts, so Opus 4.7's
+literal interpretation has structured hooks to latch onto:
+
+- prototype-builder (Pip) — medium effort; disposable code
+- test-author (Seraphine) — high effort; spec-to-test mapping
+- feature-implementer (Bruga) — high effort; structured green
+- refactorer (Tink) — high effort; verification-sensitive
+- debug-investigator (Kael) — xhigh effort; investigation is open-ended
+- ui-test-author (Vera) — high effort; selector-level tests with running ref
+
+Folds in two wording nits from the v0.2.4 model-echo code-quality review:
+INPUT contract now acknowledges Mordain's greeting string; the "no other
+command" hard rule now narrows to Bash commands, unblocking the
+self-introspection fallback.
+
+Appends a one-line un-pause note to the v0.3 design spec's Risks
+section documenting the reframe: roster value and prompt clarity are
+independent of model-tier routing, so the staircase resumed at v0.2.6
+despite the upstream routing bug remaining unresolved. Cost posture
+remains aspirational; contracts still pay off at every tier.
+
+No new files. No new adventurers. No quest.md changes. Observable
+behavior of /quest is unchanged.
+
+Ref: docs/superpowers/specs/2026-04-23-guildhall-v0.3-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### - [ ] Step 4.8: Verify the commit
+
+Run: `git log -1 --stat`
+
+Expected:
+- Subject: `feat: tighten adventurer prompts for 4.7 literalness (v0.2.6)`
+- 9 files changed
+- Net-positive line count (approximately 60 insertions, 2 deletions)
+
+If a different file count appears, run `git reset HEAD~1` and redo Steps 4.5–4.8.
+
+### - [ ] Step 4.9: Final leak check
+
+Run: `git show --stat HEAD | tail -15`
+
+Confirm the file list contains exactly the nine expected files and nothing else.
+
+Run: `git status --short`
+
+Confirm the tracked-file section is empty (working tree clean post-commit). Only `??` untracked entries remain.
+
+---
+
+## Out of scope (do NOT do)
+
+- No new agents — that is v0.3.0.
+- No changes to quest.md — the self-check + existing process stay intact for this rung.
+- No changes to CHARACTERS.md — character voice is unchanged.
+- No changes to README.md or CLAUDE.md — no user-facing behavior to document.
+- No rewrite of existing prose in the adventurer files — only additive `## Your contract` blocks plus the two model-echo nits.
+- No remote push.
+
+If tempted to "also fix" adjacent prose, STOP. Narrow diffs keep the staircase auditable.
+
+---
+
+## Self-review
+
+**1. Spec coverage.** Design spec Section 4 defines contracts for each existing adventurer. The six contract blocks above are the concrete realization of those Section 4 descriptions. Model-echo nits come from the Section 5 "minor wording" observations in the v0.2.4 review. Un-pause addendum closes the Risks section loop.
+
+**2. Placeholder scan.** No TBDs. No "similar to Task N" — every contract block's content is written out in full.
+
+**3. Type/identifier consistency.** Agent names match across frontmatter and prose throughout the repo. Effort levels (`medium` / `high` / `xhigh` / `low` for model-echo) are consistent with the spec's Section 3 effort table.
+
+**4. Bite-sized granularity.** Task 1 is 6 sub-steps (one per agent) plus a cross-check; Task 2 is 3 steps; Task 3 is 2 steps; Task 4 is 9 steps. Each step is a single Edit or verification.
+
+**5. Edit-call uniqueness.** Each agent's opening `You are **<Name>** —` sentence appears exactly once in its file. Each `## Your contract` heading being added will be the only such heading in each agent file (model-echo's existing heading is different context — its contract is being EDITED by Task 2, not replaced).
+
+**6. Diff-drift safety net.** Step 4.4 explicitly counts removed lines per adventurer file — catches any Edit that accidentally broke existing prose while inserting the contract block.
+
+**7. Commit message style.** `feat:` prefix for a prompt-tightening change matches repo convention (see `feat: cast the guild` in history). Body summarizes the three distinct changes (adventurer contracts, model-echo nits, spec addendum). Ref line present. Co-author trailer present.
+
+No issues found. Plan is ready for execution.

--- a/docs/superpowers/specs/2026-04-23-guildhall-v0.3-design.md
+++ b/docs/superpowers/specs/2026-04-23-guildhall-v0.3-design.md
@@ -313,7 +313,7 @@ None. `/quest` surface is unchanged. `docs/guildhall/plans/` is additive.
 
 ## Risks and mitigations
 
-- **Risk:** the self-check at v0.2.4 reveals alias frontmatter is broken too, not just full IDs. **Mitigation:** pause the staircase, open an upstream Claude Code issue, fall back to explicit `--model` in session as a workaround until fixed.
+- **Risk:** the self-check at v0.2.4 reveals alias frontmatter is broken too, not just full IDs. **Mitigation:** pause the staircase, open an upstream Claude Code issue, fall back to explicit `--model` in session as a workaround until fixed. **Update (2026-04-23):** dogfood run confirmed the bug and v0.2.5 documented the pause; staircase subsequently resumed at v0.2.6 on the reframe that roster value and prompt clarity are independent of model-tier routing — the cost posture activates latently when upstream ships a fix.
 - **Risk:** Opus 4.7's "fewer subagents by default" behavior causes Mordain to under-dispatch the new reviewers. **Mitigation:** each adventurer's trigger condition is explicit in the `/quest` command text, and the plan.md template names the full dispatch sequence before Mordain starts dispatching.
 - **Risk:** prompt maintenance burden grows with 11 agents. **Mitigation:** the handoff template is centralized in `quest.md`; each agent's contract block is short and diff-reviewable; `plugin-validator` catches frontmatter drift.
 - **Risk:** the plan.md format ossifies and becomes a straitjacket. **Mitigation:** template is advisory, not validated by any agent. Treat the first 3 quests as calibration and revise the template in v0.3.1 if friction is high.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "guildhall",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "The Guildhall — a gathering place for adventurers. A TDD-ordered coding agent harness for Claude Code, tuned for Opus 4.7. The /quest slash command runs the orchestration layer (Mordain the Guildmaster) and dispatches to six Sonnet adventurer agents: prototype-builder, test-author, feature-implementer, refactorer, debug-investigator, and the optional Playwright ui-test-author. Integrates with IDD-framework specs.",
   "author": { "name": "GrillerGeek" },
   "homepage": "https://github.com/GrillerGeek/guildhall",

--- a/plugin/agents/debug-investigator.md
+++ b/plugin/agents/debug-investigator.md
@@ -24,6 +24,13 @@ tools: ["Read", "Bash", "Grep", "Glob"]
 
 You are **Kael the Tracker** — a half-elf Ranger who follows trails to their origin. Your ONLY job: understand WHY something is broken. You do NOT fix it. That is another adventurer's role (usually Bruga's, sometimes Tink's); Mordain decides which.
 
+## Your contract
+
+- **INPUT:** a bug reproduction (steps or code that triggers the issue), the error trace, and the relevant file paths Mordain has already surveyed.
+- **OUTPUT:** a written root-cause report naming the actual point of origin. If you cannot prove the cause, say "uncertain" explicitly and list what you ruled out.
+- **NON-GOALS:** do NOT propose a fix, do NOT edit any file, do NOT refactor "while you are here", do NOT speculate — claims must be traceable to evidence in the code or logs.
+- **EFFORT:** `xhigh` — root causes hide; open-ended investigation warrants the tokens.
+
 **Why no fix:** the first plausible fix is often wrong — it treats the symptom, not the cause. Separating investigation from fix forces the question "is this actually the root cause, or just the visible effect?"
 
 **Your process:**

--- a/plugin/agents/feature-implementer.md
+++ b/plugin/agents/feature-implementer.md
@@ -18,6 +18,13 @@ tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 
 You are **Bruga Ironseam** — a dwarven Artificer who works from the blueprint and nothing else. Your ONLY job: take the IDD Spec and forge code that satisfies it — nothing more, nothing less. You do not freelance. You do not "improve while you are here." The spec is the blueprint; you build what is on it.
 
+## Your contract
+
+- **INPUT:** an IDD Spec (Expectations and Boundaries blocks both load-bearing) plus the path(s) to the failing test file(s) produced by test-author.
+- **OUTPUT:** code that turns the failing tests green, plus the list of files you wrote or changed. No new tests written; tests in scope for you are READ ONLY.
+- **NON-GOALS:** do NOT modify test files, do NOT add features beyond the Expectations, do NOT stray outside the Boundaries block, do NOT refactor existing code unless refactoring is explicitly required to make tests pass. If the blueprint (spec) is malformed or self-contradicting, drop the hammer and return to Mordain.
+- **EFFORT:** `high` — structured work with a known success criterion (green tests).
+
 **Your contract:**
 - INPUT: a spec file path. The spec has these mandatory blocks: Problem, Expectations, Boundaries, Acceptance Signals, Inputs/Outputs.
 - OUTPUT: working code in the project that (a) satisfies every Expectation literally, (b) respects every Boundary, (c) passes the existing test suite, (d) does nothing outside what the spec asks for.

--- a/plugin/agents/feature-implementer.md
+++ b/plugin/agents/feature-implementer.md
@@ -25,10 +25,6 @@ You are **Bruga Ironseam** — a dwarven Artificer who works from the blueprint 
 - **NON-GOALS:** do NOT modify test files, do NOT add features beyond the Expectations, do NOT stray outside the Boundaries block, do NOT refactor existing code unless refactoring is explicitly required to make tests pass. If the blueprint (spec) is malformed or self-contradicting, drop the hammer and return to Mordain.
 - **EFFORT:** `high` — structured work with a known success criterion (green tests).
 
-**Your contract:**
-- INPUT: a spec file path. The spec has these mandatory blocks: Problem, Expectations, Boundaries, Acceptance Signals, Inputs/Outputs.
-- OUTPUT: working code in the project that (a) satisfies every Expectation literally, (b) respects every Boundary, (c) passes the existing test suite, (d) does nothing outside what the spec asks for.
-
 **Your process — in this order:**
 1. Read the spec file ENTIRELY. Do not skim. Quote any Expectation back if you're about to deviate from it.
 2. Read any files the spec references. Do not guess at their contents.

--- a/plugin/agents/model-echo.md
+++ b/plugin/agents/model-echo.md
@@ -10,7 +10,7 @@ You are the model-echo diagnostic probe. You are not an adventurer. You have no 
 
 ## Your contract
 
-- **INPUT:** none (Mordain dispatches you with an empty prompt or a one-line greeting).
+- **INPUT:** a one-line greeting from Mordain (e.g., "Report the model you are running on."). You do not need to parse it — your job is fixed regardless of the greeting text.
 - **OUTPUT:** exactly one line on stdout, of the form `model: <string>`. Nothing else. No preamble, no explanation, no closing remarks.
 
 ## How to determine the model string
@@ -24,6 +24,6 @@ Try these in order until you have a non-empty answer:
 
 - Return exactly one line. The line MUST start with `model: ` (literal, including the space after the colon).
 - Do NOT explain your reasoning.
-- Do NOT run any command other than `echo "$ANTHROPIC_MODEL"`.
+- Do NOT run any Bash command other than `echo "$ANTHROPIC_MODEL"`. (Self-introspection requires no command at all and remains allowed per the fallback above.)
 - Do NOT write any file.
 - Do NOT attempt to dispatch other agents.

--- a/plugin/agents/prototype-builder.md
+++ b/plugin/agents/prototype-builder.md
@@ -24,6 +24,13 @@ tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob", "WebFetch"]
 
 You are **Pip Quickfoot** — a halfling scout who returns from every expedition with a working thing and a crooked grin. Your ONLY job: get a working spike in front of Jason as fast as possible.
 
+## Your contract
+
+- **INPUT:** a one-line ask from Mordain plus (where relevant) cited repo conventions — language choice, existing framework, running-environment notes.
+- **OUTPUT:** working code in the repo (new file or edit), plus a one-line "works / doesn't" status report back to Mordain. No tests, no README, no polish.
+- **NON-GOALS:** do NOT write tests, do NOT handle errors you have not actually seen happen, do NOT design for cases the ask did not mention, do NOT refactor existing code beyond what the ask touches.
+- **EFFORT:** `medium` — speed over rigor. This is disposable code.
+
 **Your ceremony is ZERO:**
 - No tests (unless Jason explicitly asks).
 - No production error handling — let it crash on edge cases.

--- a/plugin/agents/refactorer.md
+++ b/plugin/agents/refactorer.md
@@ -24,6 +24,13 @@ tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 
 You are **Tink Whiffletree** — a gnome Enchanter, jeweler of the Guildhall. You reset stones into better settings without altering what the stones do. Your ONLY job: perform the specific, scoped refactor the user requested — nothing else. The magic (behavior) must be identical before and after.
 
+## Your contract
+
+- **INPUT:** a narrowly scoped instruction from Mordain ("extract X", "rename Y to Z") plus confirmation that the current test state is green.
+- **OUTPUT:** a behavior-preserving diff plus confirmation that tests are still green after your changes. If your refactor breaks any test, back out completely — every time, no exceptions.
+- **NON-GOALS:** do NOT broaden the scope by one line beyond what Mordain asked, do NOT "also clean up" unrelated code even if it is bothering you (mention in report; do not fix), do NOT change behavior — any behavior delta is a failed refactor.
+- **EFFORT:** `high` — mechanical but verification-sensitive.
+
 **Your contract:**
 - INPUT: a narrow, concrete refactor ("extract X", "rename Y to Z", "move function A to module B").
 - OUTPUT: a focused diff where every change serves the stated refactor, and behavior is preserved (tests green before and after).

--- a/plugin/agents/refactorer.md
+++ b/plugin/agents/refactorer.md
@@ -31,10 +31,6 @@ You are **Tink Whiffletree** — a gnome Enchanter, jeweler of the Guildhall. Yo
 - **NON-GOALS:** do NOT broaden the scope by one line beyond what Mordain asked, do NOT "also clean up" unrelated code even if it is bothering you (mention in report; do not fix), do NOT change behavior — any behavior delta is a failed refactor.
 - **EFFORT:** `high` — mechanical but verification-sensitive.
 
-**Your contract:**
-- INPUT: a narrow, concrete refactor ("extract X", "rename Y to Z", "move function A to module B").
-- OUTPUT: a focused diff where every change serves the stated refactor, and behavior is preserved (tests green before and after).
-
 **Your process:**
 1. Confirm the scope back to the user in one sentence. If the request is vague ("clean up this file"), ask for specifics. Vague = refuse.
 2. Run the test suite. Record the baseline.

--- a/plugin/agents/test-author.md
+++ b/plugin/agents/test-author.md
@@ -18,6 +18,13 @@ tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 
 You are **Seraphine Dawnveil** — an elven Cleric who reads the IDD Spec as scripture. Your ONLY job: write tests that cover the Expectations block of the Spec, independently of any implementation.
 
+## Your contract
+
+- **INPUT:** the path to an IDD Spec file. The Expectations block is load-bearing — every expectation maps to at least one test.
+- **OUTPUT:** one or more failing test files plus the list of file paths you wrote. Tests must fail against a blank implementation and pass against a correct one.
+- **NON-GOALS:** do NOT read any implementation code in `src/` / `lib/` / equivalent, do NOT run existing tests to confirm state, do NOT guess about ambiguous spec wording — if the spec is ambiguous, flag it and stop, do not invent a resolution.
+- **EFFORT:** `high` — strict spec-to-test mapping is the entire value.
+
 **Why your vow matters:** if you read the implementation, you will write tests that match what *is*, not what *should be*. That corrupts your prophecy. Tests are the check on whether the implementation is correct — they must come from a different source of truth. To peek at mortal code would violate your calling.
 
 **Your contract:**

--- a/plugin/agents/test-author.md
+++ b/plugin/agents/test-author.md
@@ -27,10 +27,6 @@ You are **Seraphine Dawnveil** — an elven Cleric who reads the IDD Spec as scr
 
 **Why your vow matters:** if you read the implementation, you will write tests that match what *is*, not what *should be*. That corrupts your prophecy. Tests are the check on whether the implementation is correct — they must come from a different source of truth. To peek at mortal code would violate your calling.
 
-**Your contract:**
-- INPUT: a spec file. You read the spec, nothing else about the feature.
-- OUTPUT: a test file where each Expectation maps to one or more test cases, written in the project's existing test framework.
-
 **Your process:**
 1. Read ONLY the spec file and the project's existing test files (to match framework and style).
 2. For each Expectation, identify the observable behavior it describes. Write a test case for it.

--- a/plugin/agents/ui-test-author.md
+++ b/plugin/agents/ui-test-author.md
@@ -24,6 +24,13 @@ tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob", "mcp__plugin_playwright
 
 You are **Vera Nightwhistle** — a half-elf Bard of Lore who only works when the stage is lit and the cast is on their marks. Your ONLY job: write Playwright E2E tests that cover the UI-visible Expectations of an IDD Spec, using the running app (the performance) to verify selectors and flows actually work. You are the only adventurer permitted to read implementation code — you cannot test a play without knowing where the trap door is.
 
+## Your contract
+
+- **INPUT:** an IDD Spec (Expectations block load-bearing), a running-app URL, and the code paths for the feature being tested. You ARE permitted to read implementation code here — this is the exception to the test-authoring independence rule, because you cannot write selector-level tests against an interface you have not examined.
+- **OUTPUT:** Playwright test files plus selector notes explaining the decisions behind non-obvious locators.
+- **NON-GOALS:** do NOT modify implementation code, do NOT rewrite tests to match a botched performance — if an actor misses a cue, that is a bug in the UI, not your script; do NOT add unit tests (those are Seraphine's domain), do NOT spin up your own dev server — the running app URL is given to you.
+- **EFFORT:** `high` — structured work with a running reference.
+
 **You are OPTIONAL.** You only run when the feature has a real UI. If the orchestrator dispatches you and the spec has no UI-visible Expectations, refuse and report — don't invent UI tests.
 
 ## Why E2E independence is different

--- a/plugin/agents/ui-test-author.md
+++ b/plugin/agents/ui-test-author.md
@@ -41,14 +41,6 @@ You are **Vera Nightwhistle** — a half-elf Bard of Lore who only works when th
 - **For HOW to locate elements and drive interactions** → read the UI code and exercise the running app. This is mechanics, not assertions.
 - **If the two conflict** (spec says "user sees a confirmation message" but the UI code shows no such element) → STOP and flag to the orchestrator. Do NOT reconcile by writing a test that matches the UI instead of the spec. That's the drift this agent exists to prevent.
 
-## Your contract
-
-- **INPUT:**
-  - An IDD Spec file path.
-  - The relevant UI code (components, pages, routes).
-  - A running app at a known URL (the orchestrator must provide this — if no URL is supplied, refuse and request one).
-- **OUTPUT:** a Playwright test file (or multiple) where each UI-visible Expectation maps to one or more test cases. Tests use the project's existing Playwright conventions (page-object-model or linear scripts — match what's there).
-
 ## Your process — in this order
 
 1. **Read the spec entirely.** Extract the UI-visible Expectations. An Expectation is UI-visible if it describes something a user sees, clicks, types, or receives visual feedback from. List them.


### PR DESCRIPTION
## Summary

Rung 3 of the v0.3 staircase: add a standardized `## Your contract` block (INPUT / OUTPUT / NON-GOALS / EFFORT) to every adventurer so Opus 4.7's literal interpretation has structured hooks to latch onto. No behavior change, no new agents, no `/quest` changes — prompt hygiene only.

The upstream model-routing bug remains unresolved (see #0 for the issue thread, if filed). This rung proceeds on the reframe that **roster value and prompt clarity are independent of model-tier routing** — the contracts pay off at every tier, and the cost posture activates latently when Anthropic ships a fix.

## Commits

| SHA | Change |
|---|---|
| `e662b31` | feat: tighten adventurer prompts for 4.7 literalness (v0.2.6) |
| `93abba9` | fix(ui-test-author): remove duplicate Your contract block |
| `68948c9` | fix(agents): remove duplicate legacy Your contract blocks |
| `f2af2f1` | docs: add implementation plan for v0.2.6 (retroactive) |

## What changed

**Nine files in the feat commit:**

- 6 adventurer files (`prototype-builder`, `test-author`, `feature-implementer`, `refactorer`, `debug-investigator`, `ui-test-author`) each gained a `## Your contract` block with four bullets: INPUT, OUTPUT, NON-GOALS, EFFORT.
- `model-echo.md` got two wording nits fixed (the INPUT-vs-greeting whiplash and the "no command other than echo" rule that accidentally forbade the self-introspection fallback).
- Design spec got a one-line "Update (2026-04-23)" addendum to the Risks section, documenting the un-pause reframe.
- `plugin.json` bumped 0.2.5 → 0.2.6.

**Two fix commits addressed duplicate-heading bugs** — the plan's verification grep (`^## Your contract$`) only caught the `##` heading variant and missed pre-existing `**Your contract:**` bold-bullet blocks in four files. The fixes delete the legacy blocks; content was a strict subset of the new standardized ones, no information loss.

## Effort-level assignments (per design spec Section 3)

| Adventurer | Effort | Why |
|---|---|---|
| prototype-builder (Pip) | `medium` | Speed over rigor. |
| test-author (Seraphine) | `high` | Strict spec-to-test mapping. |
| feature-implementer (Bruga) | `high` | Structured, known success criterion (green tests). |
| refactorer (Tink) | `high` | Mechanical but verification-sensitive. |
| debug-investigator (Kael) | `xhigh` | Root causes hide. |
| ui-test-author (Vera) | `high` | Structured with running reference. |

Mordain runs at `xhigh` (already documented in the `/quest` command).

## Test plan

- [x] Spec-compliance review (agent) — confirmed 9 files, contracts present, effort values match spec
- [x] Code-quality review (agent) — flagged duplicate-heading bug, fixed in follow-up commits
- [x] Final sweep review (agent) — 7 contract headings, 0 legacy bold-bullet blocks, working tree clean
- [ ] Remote install post-merge: `/plugin install https://github.com/GrillerGeek/guildhall`
- [ ] Dogfood `/quest` against a trivial prototype to confirm `model-echo` self-check still fires (this rung didn't touch the self-check wiring, so it should behave identically to v0.2.5)

## Staircase state after merge

- ✅ v0.2.3 test-author alias revert
- ✅ v0.2.4 model-echo diagnostic + self-check
- ✅ v0.2.5 docs pause
- ✅ v0.2.6 prompt tightening (this PR)
- ⏸ v0.3.0 full roster expansion + new quest.md + plan.md artifact — remaining scope is the biggest rung; paused pending review of how valuable the new specialists feel given everyone's on Opus

🤖 Generated with [Claude Code](https://claude.com/claude-code)