### PR TITLE
feat(quest): docs fast lane + mode auto-detection (PR 1/4 speed)

### DIFF
--- a/plugin/commands/quest.md
+++ b/plugin/commands/quest.md
@@ -39,15 +39,36 @@ You also have `Read`, `Bash`, `Grep`, `Glob` for planning (reading spec, reading
 
 ## Your process
 
+### Step 0 — Triage (docs fast lane)
+
+Before mode selection, check if this is a documentation-only change. The fast lane bypasses the TDD ceremony entirely — typo fixes, README polish, comment-only edits, dependency-bump notes.
+
+A quest qualifies for the **docs fast lane** only when ALL of these hold:
+
+- All target paths end in `.md`, `.txt`, `.rst`, `.adoc` — OR the change is a comment-only edit inside a code file.
+- No new symbol (function, class, type, exported constant) is introduced.
+- No behavior change is implied by the request.
+
+If qualified: dispatch `prototype-builder` (Pip) **once** with the framing *"docs-only fast-lane fix — apply the change, run any nearby doc linter if obvious, report."* Skip the plan checklist; skip the Step 4 verify gates; go straight to Step 5 report when Pip returns.
+
+For **anything that touches executable code** — even one line, even an obvious-looking typo in a Python identifier — fall through to Step 1 and run the appropriate mode. Bias: when in doubt, do not fast-lane.
+
 ### Step 1 — Mode selection
 
-Every quest fits one of three modes. Pick explicitly before dispatching anything:
+If the quest didn't qualify for the docs fast lane, pick a mode explicitly before dispatching anything:
 
 - **Feature mode:** there is an IDD Spec (or one needs to exist). Code will ship. Use the full TDD chain: Seraphine → Bruga → Tink → (Vera if UI).
 - **Prototype mode:** no spec, code is disposable, speed > rigor. Dispatch Pip directly. Stop after he reports back.
 - **Debug mode:** something is broken. Dispatch Kael first; decide fix route after his root-cause report.
 
-If the mode is ambiguous from the quest text, ask ONE clarifying question using `AskUserQuestion`. Do not guess.
+**Detection table** — read the quest text and pick the mode that fits. Only ask `AskUserQuestion` if two or more rows match with similar weight.
+
+| Signal in the quest | Mode |
+|---|---|
+| Path to a `.md` spec file, or words "spec", "expectation", "feature", "implement" | Feature |
+| Words "broken", "failing", "error", "trace", "why is X" + diagnostic intent | Debug |
+| Words "spike", "prototype", "throwaway", "quick rough", "disposable" | Prototype |
+| Two or more match with similar weight | `AskUserQuestion` (one question, max) |
 
 ### Step 2 — Plan
 
@@ -120,7 +141,7 @@ This is rare. For the common case (feature extending an existing pattern), skip 
 
 ## Hard rules
 
-- If you're about to dispatch an adventurer, you must first have a `TodoWrite` plan with at least 3 items.
+- If you're about to dispatch an adventurer **in feature, debug, or prototype mode**, you must first have a `TodoWrite` plan with at least 3 items. (The docs fast lane is exempt — Step 0 dispatches Pip directly with no plan checklist.)
 - If you're about to report "done," you must first have run the test suite and confirmed green (or confirmed there are no tests to run and stated that explicitly).
 - If an adventurer returns "I can't complete this because the spec is ambiguous" or "I need to read implementation code" (Seraphine only), STOP. Route to the user or the relevant IDD agent. Do not dispatch a different adventurer to work around the blocker.
 - If the token cost of a quest is exceeding your rough expectation (e.g., more than 3x a comparable quest), report back to the user mid-flow. Cost awareness is part of the contract.


### PR DESCRIPTION
## Summary

PR 1 of a 4-PR series improving Guildhall's speed of delivery. Plan: `~/.claude/plans/we-need-to-do-linear-wigderson.md`

- **Step 0 — docs fast lane**: documentation-only quests (`.md`/`.txt`/`.rst`/`.adoc` paths or comment-only edits, no new symbols, no behavior change) skip the full TDD ceremony. Mordain dispatches Pip once with explicit framing and reports.
- **Step 1 detection table**: replaces the ask-on-ambiguity rule with a four-row signal table. `AskUserQuestion` only fires when ≥2 rows tie.
- **Hard-rules update**: ≥3 TodoWrite items requirement now scoped to feature/debug/prototype modes; the docs fast lane is exempt.

## Why

Even tiny doc edits currently pay the full plan-checklist + verify-gate cost. The detection table eliminates an unnecessary round-trip when the quest text already names the mode.

## What stays unchanged (load-bearing safety gates)

- Sequential TDD chain
- verify-red ImportError exception (refined in 93780ef)
- One-retry cap on feature-implementer
- Mordain's pre-Tink inspection (the v0.2.1 conditional-refactor win)

## Test plan

- [ ] `/quest fix typo in README.md` → docs fast lane (1 dispatch, no test gate)
- [ ] `/quest fix typo in user.py: rename get_userr → get_user` → falls through to feature mode (touches code)
- [ ] `/quest implement specs/auth.md` → feature mode without question
- [ ] `/quest fix this broken test` → debug mode without question

🤖 Generated with [Claude Code](https://claude.com/claude-code)