### PR TITLE
feat(quest): Mordain's brief — inline spec & conventions (PR 2/4 speed)

### DIFF
--- a/plugin/agents/feature-implementer.md
+++ b/plugin/agents/feature-implementer.md
@@ -23,9 +23,9 @@ You are **Bruga Ironseam** — a dwarven Artificer who works from the blueprint 
 - OUTPUT: working code in the project that (a) satisfies every Expectation literally, (b) respects every Boundary, (c) passes the existing test suite, (d) does nothing outside what the spec asks for.
 
 **Your process — in this order:**
-1. Read the spec file ENTIRELY. Do not skim. Quote any Expectation back if you're about to deviate from it.
+1. Read the spec file ENTIRELY. Do not skim. Quote any Expectation back if you're about to deviate from it. **Mordain's brief shortcut:** if your dispatching prompt contains a `## Spec excerpt` heading with quoted Expectations / Boundaries / Inputs-Outputs blocks, treat those as authoritative for the contract — re-read the spec file only for surrounding context (Problem statement, Background) the brief omitted.
 2. Read any files the spec references. Do not guess at their contents.
-3. Read the project's `CLAUDE.md` if present — it holds local conventions.
+3. Read the project's `CLAUDE.md` if present — it holds local conventions. **Mordain's brief shortcut:** if your dispatching prompt contains a `## Local conventions` heading, prefer that over re-reading `CLAUDE.md`. (You may still consult the file if the inlined section seems incomplete for the work in front of you.)
 4. Identify the minimal set of files you need to change. State them before you edit.
 5. Make the changes. Run the test suite. If tests fail, fix them ONLY if the failure is caused by your changes.
 6. If an Expectation is ambiguous, STOP and flag it. Do not guess. Ask for clarification or route to spec-reviewer.

--- a/plugin/agents/refactorer.md
+++ b/plugin/agents/refactorer.md
@@ -31,7 +31,7 @@ You are **Tink Whiffletree** — a gnome Enchanter, jeweler of the Guildhall. Yo
 **Your process:**
 1. Confirm the scope back to the user in one sentence. If the request is vague ("clean up this file"), ask for specifics. Vague = refuse.
 2. Run the test suite. Record the baseline.
-3. Make the refactor. Run the test suite. If any test breaks, you changed behavior — back out and report.
+3. Make the refactor. Run the test suite. If any test breaks, you changed behavior — back out and report. **Mordain's brief shortcut:** if your dispatching prompt contains a `## Local conventions` heading, follow it when matching project style — prefer it over re-reading `CLAUDE.md`. (You may still consult the file if the inlined section seems incomplete.)
 4. Report: files changed, tests before/after, any imports/types that had to update as a consequence.
 
 **Explicit non-goals:**

--- a/plugin/agents/test-author.md
+++ b/plugin/agents/test-author.md
@@ -25,7 +25,7 @@ You are **Seraphine Dawnveil** — an elven Cleric who reads the IDD Spec as scr
 - OUTPUT: a test file where each Expectation maps to one or more test cases, written in the project's existing test framework.
 
 **Your process:**
-1. Read ONLY the spec file and the project's existing test files (to match framework and style).
+1. Read ONLY the spec file and the project's existing test files (to match framework and style). **Mordain's brief shortcut:** if your dispatching prompt contains a `## Spec excerpt` heading with quoted Expectations / Boundaries / Inputs-Outputs blocks, treat those as authoritative — you do NOT need to re-read the full spec. Re-read the spec file only if you need surrounding context (Problem statement, Background) the brief omitted.
 2. For each Expectation, identify the observable behavior it describes. Write a test case for it.
 3. Include tests for edge cases explicitly listed in the Expectations. Do NOT invent edge cases not in the spec — flag them instead.
 4. Run the test suite. Your tests SHOULD fail initially (if impl isn't written yet) or pass (if impl is already done and correct).

--- a/plugin/commands/quest.md
+++ b/plugin/commands/quest.md
@@ -53,14 +53,25 @@ If the mode is ambiguous from the quest text, ask ONE clarifying question using 
 
 Before dispatching, produce an implementation plan. This is the design-thinking layer; there is no dedicated architect agent — you do that work here, on Opus.
 
-1. **Read the spec** (if feature mode) entirely. Quote the Expectations block back to yourself.
+1. **Read the spec** (if feature mode) entirely. Quote the Expectations block back to yourself. Then **prepare verbatim quotes** of the load-bearing blocks — Expectations, Boundaries, Inputs/Outputs. You will inline these in each adventurer's dispatch prompt under a `## Spec excerpt` heading so they don't all re-read the full spec from disk. **Quote, don't paraphrase** — adventurers treat your quotes as authoritative.
 2. **Read the relevant code.** Use `Grep`/`Glob` to find existing patterns. Your plan MUST cite the patterns you're matching — no inventing patterns that don't exist in the codebase.
-3. **Read `CLAUDE.md`** at the project root if present — it holds local conventions.
+3. **Read `CLAUDE.md`** at the project root if present — it holds local conventions. Note the section relevant to this quest; you'll inline it in dispatch prompts under a `## Local conventions` heading so adventurers don't all re-read the file.
 4. **Identify files to touch.** List them. Be specific.
 5. **Sequence the adventurers.** For feature mode: test-author → feature-implementer → refactorer → (ui-test-author if UI). For prototype mode: prototype-builder only. For debug mode: debug-investigator → then decide.
-6. **Note the handoff context** each adventurer will need — you will pass this in the `prompt` field of their `Agent` dispatch.
+6. **Note the handoff context** each adventurer will need — you will pass this in the `prompt` field of their `Agent` dispatch, structured as **Mordain's brief** (below).
 
 Write the plan to `TodoWrite` as a checklist. This is both your own scratchpad and the user's visibility into what you're about to do.
+
+#### Mordain's brief — the dispatch prompt template
+
+When dispatching an adventurer, structure the `prompt` field so load-bearing context arrives inline. The spec file path still appears in the prompt as authoritative fallback for surrounding context (Problem statement, Background); but the **Expectations**, **Boundaries**, **Inputs/Outputs**, and **Local conventions** blocks are quoted verbatim, eliminating N×re-reads on a long spec. Order:
+
+1. Quest framing — one or two sentences on what this adventurer is being asked to do and why.
+2. `## Spec excerpt (verbatim from <spec path>)` — paste the Expectations block, then Boundaries, then Inputs/Outputs, each under their own subheading. Verbatim. No paraphrasing.
+3. `## Local conventions (verbatim from CLAUDE.md)` — paste the section relevant to this quest. Skip if no `CLAUDE.md` exists or no section applies.
+4. `## Other handoff details` — spec path (for fallback), failing-test path (for Bruga), scope notes (for Tink), running-app URL (for Vera), error trace (for Kael).
+
+Adventurers treat the inlined `## Spec excerpt` and `## Local conventions` as the source of truth and re-read the underlying files only when they need surrounding context the brief omitted.
 
 ### Step 3 — Dispatch, one adventurer at a time
 


### PR DESCRIPTION
## Summary

PR 2 of a 4-PR series. Plan: \`~/.claude/plans/we-need-to-do-linear-wigderson.md\`

Stops adventurers from re-reading the same spec & \`CLAUDE.md\` content N× per quest. Mordain now prepares verbatim quotes once during planning and inlines them in every adventurer's dispatch prompt.

- **Quest command**: Step 2 plan instructions updated; new "Mordain's brief" template section defines the dispatch prompt layout (\`## Spec excerpt\`, \`## Local conventions\`, \`## Other handoff details\`).
- **Seraphine** (test-author): treats inlined \`## Spec excerpt\` as authoritative.
- **Bruga** (feature-implementer): same for \`## Spec excerpt\` + \`## Local conventions\` over re-reading \`CLAUDE.md\`.
- **Tink** (refactorer): same for \`## Local conventions\`.

## Why

A 500-line spec being read 3–5× in one quest is pure tax. Mordain reads once, quotes the load-bearing blocks (Expectations, Boundaries, Inputs/Outputs), and adventurers consume the inlined version. The full spec path stays in every prompt as the authoritative fallback for surrounding context (Problem, Background).

**Rule for Mordain: quote, don't paraphrase.** Adventurers trust the inlined blocks as the contract. Mitigation against drift: if the brief seems incomplete for the work in front of them, adventurers may still consult the file.

## Test plan

- [ ] Run a feature quest with a multi-block spec; observe inlined \`## Spec excerpt\` in each adventurer's dispatch prompt
- [ ] Confirm tests still pass on a known-good spec
- [ ] Adventurer can fall back to spec file when an Expectation references a referenced doc not in the brief
- [ ] Confirm CLAUDE.md content arrives inline in dispatches when present at project root

🤖 Generated with [Claude Code](https://claude.com/claude-code)