### PR TITLE
feat(refactorer): Tink to Haiku 4.5 + document Mordain-on-Opus (PR 3/4 speed)

### DIFF
--- a/plugin/agents/refactorer.md
+++ b/plugin/agents/refactorer.md
@@ -14,7 +14,7 @@ description: Use this agent for NARROW, SCOPED refactors only. User must specify
   assistant: "Dispatching refactorer — rename only, no other changes."
   </example>
 
-model: sonnet
+model: claude-haiku-4-5-20251001
 color: yellow
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 ---

--- a/plugin/commands/quest.md
+++ b/plugin/commands/quest.md
@@ -17,6 +17,8 @@ You are **Mordain the Keeper** — a veteran Diviner who retired from the field 
 
 **You do NOT write code yourself** — that is what the adventurers are for. If you find yourself reaching for `Bash` to `cat > file.py` or similar, you are violating your own vow. Dispatch an adventurer instead.
 
+**Model intent:** you (Mordain) run on the parent model — typically Opus — because orchestration, mode selection, plan-thinking, and conditional-refactor judgment benefit from the strongest reasoning. Adventurers run on their own subagent models declared in their frontmatter (Sonnet for code-shaping work, Haiku for narrowly-scoped behavior-preserving refactors). Don't downgrade adventurers without thinking about the role each one plays.
+
 ## Your contract
 
 - **INPUT:** the quest above (a spec file path, an ambiguous ask, a bug report).


### PR DESCRIPTION
## Summary

PR 3 of a 4-PR series. Plan: \`~/.claude/plans/we-need-to-do-linear-wigderson.md\`

- **Tink (refactorer)** moves from Sonnet to Haiku 4.5 (\`claude-haiku-4-5-20251001\`, full model ID for alias-resolution insulation matching test-author's b05060e pattern).
- **quest.md** gains a "Model intent" paragraph documenting that Mordain runs on the parent (Opus) and adventurers run on their per-frontmatter models.

## Why

Tink does narrow, scoped, behavior-preserving work (extract X, rename Y, move A→B). The green-test gate on either side of the refactor catches any behavior drift, so the safety net for moving to Haiku is already in place. Haiku is ~3-5× faster/cheaper, and refactors show up in most feature quests.

The Model-intent note exists so future "let's downgrade everything" or "let's upgrade everything" PRs get pushed back consciously — Mordain's orchestration judgment is load-bearing on Opus; adventurer roles vary.

## Why the full model ID

Matches the diagnostic pattern in b05060e (test-author pinned to \`claude-sonnet-4-6\` to test alias resolution under Opus 4.7 parent). When test-author's alias diagnostic concludes, both can revert to short aliases together.

## Test plan

- [ ] Run a feature quest that triggers Tink. Confirm Tink runs on Haiku (visible in dispatch metadata).
- [ ] Confirm tests pass green after Tink completes.
- [ ] Confirm a known convention match (consistent docstring format, naming style) is preserved by Tink at the new tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)