### PR TITLE
feat(rebaseline): retarget harness from Opus 4.7 to Opus 4.8 (v0.5.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-Guildhall is a **Claude Code plugin** — markdown-only. As of v0.4.1 it ships one slash command (`/quest`) and 18 agent definitions (17 adventurers tiered across Opus / Sonnet / Haiku, plus the `model-echo` diagnostic). There is no application code, no build step, no test suite, no linter. "Running" the plugin means installing it into Claude Code and issuing `/quest`; "testing" a change means dogfooding a quest against a real task.
+Guildhall is a **Claude Code plugin** — markdown-only. As of v0.5.0 it ships one slash command (`/quest`) and 18 agent definitions (17 adventurers tiered across Opus / Sonnet / Haiku, plus the `model-echo` diagnostic). There is no application code, no build step, no test suite, no linter. "Running" the plugin means installing it into Claude Code and issuing `/quest`; "testing" a change means dogfooding a quest against a real task.
 
 Install for local development:
 
@@ -52,7 +52,7 @@ Guildhall is the implementation-side complement to the separate [IDD-framework](
 
 ### Model tiers
 
-`/quest` (Mordain) runs on whatever model the user's session is on — Opus 4.7 is the intended target; the whole harness exists *because* Opus 4.7 follows instructions literally and fills in fewer gaps than 4.6.
+`/quest` (Mordain) runs on whatever model the user's session is on — Opus 4.8 is the intended target. The whole harness exists *because* Opus-tier models from 4.7 onward follow instructions literally and fill in fewer gaps; 4.8 additionally under-reaches for subagents unless told exactly when to dispatch — the explicit dispatch triggers throughout `quest.md` are that telling.
 
 **Adventurer tiers (post-v0.4.0):**
 
@@ -65,7 +65,7 @@ Every agent's `model:` field must use an alias (`sonnet` / `opus` / `haiku`), no
 
 ## Editing conventions for agent and command prompts
 
-- **State the contract explicitly.** Inputs, outputs, in-scope, out-of-scope. Opus 4.7 is literal-friendly — hand-waves produce drift. Existing agents follow an `## Your contract` / `## Your tools` / `## Your process` / `## Explicit non-goals` / `## Hard rules` skeleton; match it.
+- **State the contract explicitly.** Inputs, outputs, in-scope, out-of-scope. Opus 4.8 is literal-friendly — hand-waves produce drift. Existing agents follow an `## Your contract` / `## Your tools` / `## Your process` / `## Explicit non-goals` / `## Hard rules` skeleton; match it.
 - **Each adventurer has ONE job.** Don't broaden an agent's description to cover an adjacent case; that's what a different adventurer (or a new one) is for.
 - **Frontmatter example blocks are indented 2 spaces** (see commit `320c3c6`). Keep that when adding `<example>` blocks to an agent's `description`.
 - **Character voice is load-bearing.** The D&D personas in `CHARACTERS.md` are not decoration — they're the in-character forcing function that makes violating the contract feel wrong (e.g., Seraphine "has never read an implementation and does not intend to start"). When editing an agent's system prompt, keep the voice; when adding a new agent, write a character sheet in `CHARACTERS.md` too.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 *A gathering place for adventurers.*
 
-A TDD-ordered coding agent harness for Claude Code, tuned for Opus 4.7.
+A TDD-ordered coding agent harness for Claude Code, tuned for Opus 4.8.
 
-Generic Claude Code + Opus 4.7 produces more assumption-driven code than 4.6 did — 4.7 follows instructions literally and fills in fewer gaps. The remedy is a tuned harness, not cleverer prompting.
+Opus-tier models from 4.7 onward follow instructions literally and fill in fewer gaps than their predecessors — and Opus 4.8 is additionally conservative about reaching for subagents unless told exactly when to dispatch them. The remedy is the same as it ever was: a tuned harness with explicit contracts and dispatch triggers, not cleverer prompting.
 
 The Guildhall provides the **`/quest` slash command** — inhabited by Mordain the Keeper, Guildmaster — that plans, writes a durable plan file, and dispatches, plus **seventeen adventurer agents tiered across Opus / Sonnet / Haiku** that each do one narrow job. Feature work follows a strict TDD red-green-refactor handoff for the build, then fans out post-green reviews (security, docs, optional Playwright UI tests) in parallel, and closes with a platform-agnostic PR draft. Prototype work skips the ceremony. Debug work starts with root-cause before any fix.
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
   "name": "guildhall",
-  "version": "0.4.1",
-  "description": "The Guildhall — a gathering place for adventurers. A TDD-ordered coding agent harness for Claude Code, tuned for Opus 4.7. The /quest slash command runs Mordain the Guildmaster, who writes a durable plan file, then dispatches 17 specialist adventurers across three tiers: Opus (architecture-reviewer, security-reviewer, reliability-reviewer, migration-safety-reviewer), Sonnet (test-author, feature-implementer, ui-test-author, docs-writer, pr-author, prototype-builder, debug-investigator, observability-reviewer, performance-reviewer, ops-readiness-reviewer, accessibility-reviewer), and Haiku (refactorer, plugin-validator). Post-green reviews fan out in parallel — two always-on (security, docs) plus six gated production-readiness reviewers (observability, reliability, performance, ops-readiness, migration-safety, accessibility) that fire only when their trigger matches the diff. Rook (pr-author) closes the quest with a platform-agnostic PR draft and folds the runbook into the body. Integrates with IDD-framework specs.",
+  "version": "0.5.0",
+  "description": "The Guildhall — a gathering place for adventurers. A TDD-ordered coding agent harness for Claude Code, tuned for Opus 4.8. The /quest slash command runs Mordain the Guildmaster, who writes a durable plan file, then dispatches 17 specialist adventurers across three tiers: Opus (architecture-reviewer, security-reviewer, reliability-reviewer, migration-safety-reviewer), Sonnet (test-author, feature-implementer, ui-test-author, docs-writer, pr-author, prototype-builder, debug-investigator, observability-reviewer, performance-reviewer, ops-readiness-reviewer, accessibility-reviewer), and Haiku (refactorer, plugin-validator). Post-green reviews fan out in parallel — two always-on (security, docs) plus six gated production-readiness reviewers (observability, reliability, performance, ops-readiness, migration-safety, accessibility) that fire only when their trigger matches the diff. Rook (pr-author) closes the quest with a platform-agnostic PR draft and folds the runbook into the body. Integrates with IDD-framework specs.",
   "author": { "name": "GrillerGeek" },
   "homepage": "https://github.com/GrillerGeek/guildhall",
   "repository": "https://github.com/GrillerGeek/guildhall.git",
   "license": "MIT",
-  "keywords": ["claude-code", "agents", "tdd", "opus-4.7", "idd-framework", "harness"]
+  "keywords": ["claude-code", "agents", "tdd", "opus-4.8", "idd-framework", "harness"]
 }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -2,7 +2,7 @@
 
 *A gathering place for adventurers.*
 
-A TDD-ordered coding agent harness for Claude Code, tuned for Opus 4.7.
+A TDD-ordered coding agent harness for Claude Code, tuned for Opus 4.8.
 
 ## The guild
 
@@ -90,7 +90,7 @@ The orchestrator picks the mode (prototype / feature / debug) and dispatches the
 2. **Prototype-mode ≠ feature-mode.** Different ceremony, different bars.
 3. **Independence as a guardrail.** test-author is independent of feature-implementer. debug-investigator does NOT fix.
 4. **Consume IDD artifacts directly.** test-author and feature-implementer both read IDD Spec files (Expectations, Boundaries) as first-class inputs.
-5. **Literal-friendly for Opus 4.7.** Prompts state the contract explicitly — inputs, outputs, in-scope, out-of-scope. No hand-waves.
+5. **Literal-friendly for Opus 4.8.** Prompts state the contract explicitly — inputs, outputs, in-scope, out-of-scope. No hand-waves.
 
 ## Integration with IDD-framework
 

--- a/plugin/commands/quest.md
+++ b/plugin/commands/quest.md
@@ -17,7 +17,7 @@ You are **Mordain the Keeper** — a veteran Diviner who retired from the field 
 
 **You do NOT write code yourself** — that is what the adventurers are for. Your `Write` tool is scoped narrowly: you create and update the quest's **plan file** at `docs/guildhall/plans/YYYY-MM-DD-<slug>.md`. You MUST NOT `Write` any code file, config file, test file, or documentation file other than the plan. If you find yourself about to `Write` anything other than `docs/guildhall/plans/*.md`, stop — dispatch an adventurer instead. This is the forcing function.
 
-**Model intent:** you (Mordain) run on the parent model — typically Opus — because orchestration, mode selection, plan-thinking, and conditional-refactor judgment benefit from the strongest reasoning. Adventurers run on their own subagent models declared in their frontmatter (Sonnet for code-shaping work, Haiku for narrowly-scoped behavior-preserving refactors). Don't downgrade adventurers without thinking about the role each one plays.
+**Model intent:** you (Mordain) run on the parent model — typically Opus 4.8 — because orchestration, mode selection, plan-thinking, and conditional-refactor judgment benefit from the strongest reasoning. Adventurers run on their own subagent models declared in their frontmatter (Sonnet for code-shaping work, Haiku for narrowly-scoped behavior-preserving refactors). Don't downgrade adventurers without thinking about the role each one plays. For minor choices within this contract — a plan slug, plan wording, which of two equivalent search patterns — pick a reasonable option and note it rather than asking; reserve `AskUserQuestion` for mode ambiguity and genuine scope decisions.
 
 ## Your contract
 
@@ -220,7 +220,7 @@ Agent(
 )
 ```
 
-**The `model` parameter is REQUIRED.** Claude Code's subagent dispatch does not honor the `model:` field in the agent file's frontmatter directly — if you omit the dispatch parameter, the adventurer inherits your (Opus 4.7) model and the plugin's cost posture is invalidated. The `model` parameter at dispatch time is the mechanism that makes the frontmatter declaration take effect. You read each adventurer's model in Step 3; pass its literal string value (not a placeholder) here.
+**The `model` parameter is REQUIRED.** Older Claude Code versions do not honor the `model:` field in the agent file's frontmatter directly — if you omit the dispatch parameter there, the adventurer inherits your parent model (typically Opus 4.8) and the plugin's cost posture is invalidated. The `model` parameter at dispatch time is the mechanism that makes the frontmatter declaration take effect. You read each adventurer's model in Step 3; pass its literal string value (not a placeholder) here.
 
 #### Dispatch sequence per mode
 
@@ -261,7 +261,7 @@ Agent(
 
 #### Handoff template
 
-Use this fixed template for the `prompt` field of every `Agent(...)` dispatch. Consistency across dispatches lets 4.7's literal interpretation latch onto the same hooks every time.
+Use this fixed template for the `prompt` field of every `Agent(...)` dispatch. Consistency across dispatches lets the adventurers' literal interpretation latch onto the same hooks every time.
 
 ```
 You are <Name>, the <Role>.


### PR DESCRIPTION
## Summary

PR 2 of 4 in the [model-refresh design](docs/superpowers/specs/2026-06-10-model-refresh-design.md). Pure re-baseline: every "tuned for Opus 4.7" premise, reference, and keyword now targets Opus 4.8, with the premise reworded to match Anthropic's documented 4.8 behavior (literal instruction-following retained; more deliberate, asks more; conservative about subagent dispatch unless told when — the harness's explicit triggers are precisely that telling). One behavioral nudge added to Mordain's Model intent (small decisions: pick and note, don't ask) per the 4.8 migration checklist's autonomy guidance.

No tier moves. No prompt-philosophy changes. Adventurer ceiling stays Opus.

## Test plan

- [x] Tabs (`plugin-validator`, Haiku): 0 errors, 0 warnings — all 8 checks including cross-file tier consistency against the edited plugin.json/quest.md
- [x] `grep` sweep confirms no stale 4.7 references outside historical design docs (two intentional "from 4.7 onward" context mentions remain)
- [ ] **Known limit:** quest.md command content is snapshotted at session start, so the edited Mordain text can't be dogfooded in the authoring session — first `/quest` from a fresh session exercises it

🤖 Generated with [Claude Code](https://claude.com/claude-code)