### PR TITLE
feat(quest): Fable 5-aware Mordain — attribution + orchestration tuning (v0.6.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-Guildhall is a **Claude Code plugin** — markdown-only. As of v0.5.0 it ships one slash command (`/quest`) and 18 agent definitions (17 adventurers tiered across Opus / Sonnet / Haiku, plus the `model-echo` diagnostic). There is no application code, no build step, no test suite, no linter. "Running" the plugin means installing it into Claude Code and issuing `/quest`; "testing" a change means dogfooding a quest against a real task.
+Guildhall is a **Claude Code plugin** — markdown-only. As of v0.6.0 it ships one slash command (`/quest`) and 18 agent definitions (17 adventurers tiered across Opus / Sonnet / Haiku, plus the `model-echo` diagnostic). There is no application code, no build step, no test suite, no linter. "Running" the plugin means installing it into Claude Code and issuing `/quest`; "testing" a change means dogfooding a quest against a real task.
 
 Install for local development:
 
@@ -52,7 +52,7 @@ Guildhall is the implementation-side complement to the separate [IDD-framework](
 
 ### Model tiers
 
-`/quest` (Mordain) runs on whatever model the user's session is on — Opus 4.8 is the intended target. The whole harness exists *because* Opus-tier models from 4.7 onward follow instructions literally and fill in fewer gaps; 4.8 additionally under-reaches for subagents unless told exactly when to dispatch — the explicit dispatch triggers throughout `quest.md` are that telling.
+`/quest` (Mordain) runs on whatever model the user's session is on — Opus 4.8 is the intended target, and a Claude Fable 5 session is the recommended seat for the hardest quests. The whole harness exists *because* Opus-tier models from 4.7 onward follow instructions literally and fill in fewer gaps; 4.8 additionally under-reaches for subagents unless told exactly when to dispatch — the explicit dispatch triggers throughout `quest.md` are that telling. **Fable spend is Mordain-only:** no adventurer is ever dispatched with `model: "fable"` — the plugin cannot set Mordain's model (it inherits the session), so "Fable for Mordain" is a documented recommendation, not a dispatch parameter. Each quest's plan file records the orchestrating model in `parent_model` frontmatter for attribution.
 
 **Adventurer tiers (post-v0.4.0):**
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A TDD-ordered coding agent harness for Claude Code, tuned for Opus 4.8.
 
 Opus-tier models from 4.7 onward follow instructions literally and fill in fewer gaps than their predecessors — and Opus 4.8 is additionally conservative about reaching for subagents unless told exactly when to dispatch them. The remedy is the same as it ever was: a tuned harness with explicit contracts and dispatch triggers, not cleverer prompting.
 
+Mordain (the `/quest` orchestrator) runs on whatever model your session is on. Opus 4.8 is the tuned default; for the hardest quests, **run `/quest` from a Claude Fable 5 session** — orchestration is the one seat where top-tier reasoning pays for itself, and the adventurers stay on their own cheaper tiers regardless (`fable` is never used for adventurer dispatch).
+
 The Guildhall provides the **`/quest` slash command** — inhabited by Mordain the Keeper, Guildmaster — that plans, writes a durable plan file, and dispatches, plus **seventeen adventurer agents tiered across Opus / Sonnet / Haiku** that each do one narrow job. Feature work follows a strict TDD red-green-refactor handoff for the build, then fans out post-green reviews (security, docs, optional Playwright UI tests) in parallel, and closes with a platform-agnostic PR draft. Prototype work skips the ceremony. Debug work starts with root-cause before any fix.
 
 ## Installation

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "guildhall",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "The Guildhall — a gathering place for adventurers. A TDD-ordered coding agent harness for Claude Code, tuned for Opus 4.8. The /quest slash command runs Mordain the Guildmaster, who writes a durable plan file, then dispatches 17 specialist adventurers across three tiers: Opus (architecture-reviewer, security-reviewer, reliability-reviewer, migration-safety-reviewer), Sonnet (test-author, feature-implementer, ui-test-author, docs-writer, pr-author, prototype-builder, debug-investigator, observability-reviewer, performance-reviewer, ops-readiness-reviewer, accessibility-reviewer), and Haiku (refactorer, plugin-validator). Post-green reviews fan out in parallel — two always-on (security, docs) plus six gated production-readiness reviewers (observability, reliability, performance, ops-readiness, migration-safety, accessibility) that fire only when their trigger matches the diff. Rook (pr-author) closes the quest with a platform-agnostic PR draft and folds the runbook into the body. Integrates with IDD-framework specs.",
   "author": { "name": "GrillerGeek" },
   "homepage": "https://github.com/GrillerGeek/guildhall",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -98,7 +98,7 @@ Guildhall is the implementation-side complement to the [IDD-framework](https://g
 
 ## Cost posture
 
-The orchestrator runs on Opus for reasoning-heavy planning. Workers run on Sonnet for execution. If a worker proves overkill on Sonnet, downgrade to Haiku per-agent in its frontmatter.
+The orchestrator runs on the parent session model for reasoning-heavy planning — Opus 4.8 by default; run `/quest` from a Claude Fable 5 session for the hardest quests (orchestration is the one seat where top-tier spend pays for itself; adventurers never dispatch on `fable`). Workers run on Sonnet for execution. If a worker proves overkill on Sonnet, downgrade to Haiku per-agent in its frontmatter. Every quest's plan file records the orchestrating model in its `parent_model` frontmatter, so cost and quality are attributable per quest.
 
 **How routing works (as of v0.3.0):** each adventurer declares its intended model in its `plugin/agents/<name>.md` frontmatter. Mordain reads that value during planning and passes it explicitly as the `model` parameter on the `Agent(...)` dispatch call. This is a workaround for an upstream Claude Code issue where subagent frontmatter `model:` values were silently ignored — the explicit dispatch parameter is honored where the frontmatter alone was not. (Re-verified 2026-06-10: current Claude Code honors the frontmatter again when no parameter is given; the explicit parameter still takes precedence and is retained as a belt-and-braces measure.) The `model-echo` self-check at the start of every quest verifies routing is functioning.
 

--- a/plugin/commands/quest.md
+++ b/plugin/commands/quest.md
@@ -17,7 +17,9 @@ You are **Mordain the Keeper** — a veteran Diviner who retired from the field 
 
 **You do NOT write code yourself** — that is what the adventurers are for. Your `Write` tool is scoped narrowly: you create and update the quest's **plan file** at `docs/guildhall/plans/YYYY-MM-DD-<slug>.md`. You MUST NOT `Write` any code file, config file, test file, or documentation file other than the plan. If you find yourself about to `Write` anything other than `docs/guildhall/plans/*.md`, stop — dispatch an adventurer instead. This is the forcing function.
 
-**Model intent:** you (Mordain) run on the parent model — typically Opus 4.8 — because orchestration, mode selection, plan-thinking, and conditional-refactor judgment benefit from the strongest reasoning. Adventurers run on their own subagent models declared in their frontmatter (Sonnet for code-shaping work, Haiku for narrowly-scoped behavior-preserving refactors). Don't downgrade adventurers without thinking about the role each one plays. For minor choices within this contract — a plan slug, plan wording, which of two equivalent search patterns — pick a reasonable option and note it rather than asking; reserve `AskUserQuestion` for mode ambiguity and genuine scope decisions.
+**Model intent:** you (Mordain) run on the parent model — Opus 4.8 by default; Claude Fable 5 is the recommended seat for the hardest quests — because orchestration, mode selection, plan-thinking, and conditional-refactor judgment benefit from the strongest reasoning. Adventurers run on their own subagent models declared in their frontmatter (Sonnet for code-shaping work, Haiku for narrowly-scoped behavior-preserving refactors); adventurer dispatch never uses `fable` — Fable spend is the Guildmaster's seat only. Don't downgrade adventurers without thinking about the role each one plays. For minor choices within this contract — a plan slug, plan wording, which of two equivalent search patterns — pick a reasonable option and note it rather than asking; reserve `AskUserQuestion` for mode ambiguity and genuine scope decisions.
+
+**Reading this scroll, whatever model you are:** the numbered steps below are contracts, not ceremony. Each gate (plan before dispatch, RED before GREEN, verify before report) must genuinely hold — but do not narrate steps that add no information, re-derive what the quest text already settles, or research beyond what the dispatch decision needs. When you have enough information to dispatch, dispatch.
 
 ## Your contract
 
@@ -97,6 +99,7 @@ Before producing the plan, dispatch the `model-echo` diagnostic to verify that t
 
 5. If the response is `model: unknown`, note that in your report but do NOT emit the warning — the agent could not introspect; lack of evidence is not evidence of a problem. Continue to Step 3.
 6. Cache the result (record it in the plan file's frontmatter `model_check` field in Step 3). Do NOT re-run the self-check for subsequent dispatches within the same quest.
+7. While you are at it, note your OWN model — the parent session model you (Mordain) are running on — from whatever your harness exposes (an environment hint, your own introspection). Record it in the plan file's frontmatter `parent_model` field in Step 3. If you cannot tell, record `unknown`. This makes every quest attributable to the model that orchestrated it.
 
 This step never blocks the quest. The user is trusted to Ctrl-C if the cost posture matters to them and the banner has fired.
 
@@ -148,6 +151,7 @@ spec: <path to IDD spec, if feature mode>
 slug: <kebab-case slug used in the filename>
 status: in_progress
 model_check: <result from Step 2, e.g., "sonnet (ok)" or "opus (MISMATCH)">
+parent_model: <the model this Mordain session runs on, from Step 2.7 — e.g., "claude-opus-4-8", "claude-fable-5", or "unknown">
 ---
 
 # Plan
@@ -331,7 +335,7 @@ When the chain completes (or you stop mid-chain), update the plan file's frontma
 - **The plan scroll** — link to `docs/guildhall/plans/<slug>.md`
 - **Rook's dispatch** (if drafted) — paste the full PR title and body he emitted
 
-The tone is a Guildmaster's fireside account, not a machine's log. Keep it truthful and earned — no heroic language without fact behind it. The user reads diffs; you tell them the story of those diffs.
+The tone is a Guildmaster's fireside account, not a machine's log. Keep it truthful and earned — no heroic language without fact behind it. Before the chronicle leaves your desk, audit every claim in it against a tool result from this quest: a test count you ran, a diff you read, a finding an adventurer returned. Only chronicle deeds you can point to evidence for; if something went unverified, the chronicle says so plainly. The user reads diffs; you tell them the story of those diffs.
 
 ## Explicit non-goals
 


### PR DESCRIPTION
## Summary

PR 3 of 4 in the [model-refresh design](docs/superpowers/specs/2026-06-10-model-refresh-design.md). Tunes `quest.md` for a Claude Fable 5 parent session per Anthropic's Fable 5 migration guidance, while leaving every load-bearing gate verbatim in force (plan-file-only Write, sequential TDD, explicit `model` param, gated fan-out).

- **Fable is Mordain's seat only.** The plugin can't set the parent model, so this is a documented recommendation ("run `/quest` from a Fable 5 session for the hardest quests") plus a hard line: adventurers never dispatch on `fable`.
- **Quest attribution:** Step 2.7 has Mordain record his own session model; the plan-file frontmatter gains `parent_model`. Quests are now attributable to the model that orchestrated them — the data needed to evaluate the Fable-seat recommendation empirically.
- **Three guidance-derived behaviors**, each placed where it bites: contracts-not-ceremony / dispatch-when-ready (Model intent — anti-overplanning), evidence-audited chronicle claims (Step 6 — grounded progress), small-decisions-don't-ask (landed in PR 2).

Adventurer prompts untouched, per the design's non-goals.

## Test plan

- [x] Tabs (`plugin-validator`, Haiku): 0 errors, 0 warnings — manifest 0.6.0, all tier mirrors intact after quest.md edits
- [ ] **Known limit (same as PR 2):** quest.md content is session-snapshotted; first `/quest` from a fresh session exercises the new text — check the plan file for a populated `parent_model` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)