### PR TITLE
feat(routing): roster-table tier resolution + friction fixes (v0.6.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-Guildhall is a **Claude Code plugin** — markdown-only. As of v0.6.0 it ships one slash command (`/quest`) and 18 agent definitions (17 adventurers tiered across Opus / Sonnet / Haiku, plus the `model-echo` diagnostic). There is no application code, no build step, no test suite, no linter. "Running" the plugin means installing it into Claude Code and issuing `/quest`; "testing" a change means dogfooding a quest against a real task.
+Guildhall is a **Claude Code plugin** — markdown-only. As of v0.6.1 it ships one slash command (`/quest`) and 18 agent definitions (17 adventurers tiered across Opus / Sonnet / Haiku, plus the `model-echo` diagnostic). There is no application code, no build step, no test suite, no linter. "Running" the plugin means installing it into Claude Code and issuing `/quest`; "testing" a change means dogfooding a quest against a real task — **from a freshly started session**: Claude Code snapshots command/skill content at session start, so a `/quest` issued in the session that edited `quest.md` exercises the stale snapshot, not your change (verified 2026-06-10). Agent files are read at dispatch time and don't have this constraint.
 
 Install for local development:
 
@@ -40,11 +40,11 @@ When editing `quest.md`, preserve this three-phase shape. Serializing the review
 
 ### Subagent model routing requires the explicit `model` dispatch parameter
 
-When this workaround shipped, Claude Code's subagent dispatch did **not** honor the `model:` field in an agent file's frontmatter directly — the agent inherited the parent session's model instead (verified via `model-echo` diagnostic on 2026-04-23). Guildhall works around this by having Mordain read each adventurer's `model:` from its frontmatter (the canonical source) and pass it **explicitly** as the `model` parameter on every `Agent(...)` dispatch. The `Agent` tool's `model` parameter IS honored.
+When this workaround shipped, Claude Code's subagent dispatch did **not** honor the `model:` field in an agent file's frontmatter directly — the agent inherited the parent session's model instead (verified via `model-echo` diagnostic on 2026-04-23). Guildhall works around this by having Mordain pass each adventurer's tier **explicitly** as the `model` parameter on every `Agent(...)` dispatch. The `Agent` tool's `model` parameter IS honored. As of v0.6.1 Mordain resolves tiers from the roster table inside `quest.md` itself (a validator-enforced mirror of the canonical frontmatter — check 8) instead of Glob+Reading every agent file per quest; the file-read path remains as fallback for agents missing from the table.
 
 **Re-verified 2026-06-10:** current Claude Code now honors the frontmatter `model:` when no dispatch parameter is given (model-echo dispatched with no `model` param reported Sonnet under a non-Sonnet parent), and the explicit parameter still works and takes precedence over frontmatter. The explicit-param workaround is **retained** as belt-and-braces — older Claude Code versions in the field still need it, and the cost posture depends on routing being right. Deciding whether to retire it is PR 4 scope in `docs/superpowers/specs/2026-06-10-model-refresh-design.md`.
 
-This means: (a) every `Agent(...)` call in `quest.md` must include the `model` parameter — no exceptions; (b) every agent file must declare `model:` in alias form (`sonnet` / `opus` / `haiku`), never a full model ID; (c) when adding a new agent, also add the read-model step in `quest.md`'s Step 3 if the new agent is dispatched outside the existing sequence.
+This means: (a) every `Agent(...)` call in `quest.md` must include the `model` parameter — no exceptions; (b) every agent file must declare `model:` in alias form (`sonnet` / `opus` / `haiku`), never a full model ID; (c) when adding a new agent, add its row to the `quest.md` roster table (Mordain's dispatch-time tier source) — plugin-validator check 8 will fail if the row and the frontmatter ever disagree.
 
 ### IDD-framework is the upstream spec producer
 

--- a/docs/superpowers/specs/2026-06-10-model-refresh-design.md
+++ b/docs/superpowers/specs/2026-06-10-model-refresh-design.md
@@ -62,6 +62,14 @@ Retarget every "tuned for Opus 4.7" premise, reference, and keyword (`quest.md`,
 
 Scoped after PRs 1–3 dogfooding. Candidate pool: smarter post-green batching, quest-level token budget awareness, chronicle improvements, anything routing re-verification surfaced. Scope decided then; non-goals above still bind.
 
+**Scope as decided (v0.6.1)** — three items, each from observed friction:
+
+1. **model-echo hardening** — on Haiku it prepended an `$ANTHROPIC_MODEL` explanation, violating its one-line contract (appendix, test B). Two prompt-hardening rounds reduced but did not eliminate Haiku's preamble (each round verifiably changed behavior — confirming agent files ARE read at dispatch time, unlike command content). Resolution: robust parse contract instead — the reply MUST end with the `model:` line, and quest.md Step 2.3 parses that line, ignoring any narration before it. Observed Haiku outputs already satisfy this.
+2. **Workaround decision: retain the explicit `model` param, retire the per-quest file reads.** The explicit param stays (older Claude Code in the field; cost posture). But Step 3.9's Glob+Read of every agent file per quest is replaced by reading the quest.md roster table — trustworthy because check 8 (PR 1) validator-enforces it as a mirror of frontmatter. File-read path remains as fallback for table-missing agents. Saves N file-read roundtrips per quest.
+3. **Dogfood protocol documented** — command/skill content is snapshotted at session start (observed when the PR 1 gate quest ran a pre-speed-series quest.md), so dogfooding a quest.md change requires a freshly started session. Recorded in CLAUDE.md; agent files are dispatch-time reads and unaffected.
+
+Skipped (no observed friction, YAGNI): post-green batching changes, quest-level token budget awareness, chronicle format changes.
+
 ## Validation strategy
 
 Per PR: Tabs (`plugin-validator`) clean on the plugin tree, then a real `/quest` dogfood run (the repo's definition of testing), then merge. Commit style `type(scope): summary (vX.Y.Z)`.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "guildhall",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The Guildhall — a gathering place for adventurers. A TDD-ordered coding agent harness for Claude Code, tuned for Opus 4.8. The /quest slash command runs Mordain the Guildmaster, who writes a durable plan file, then dispatches 17 specialist adventurers across three tiers: Opus (architecture-reviewer, security-reviewer, reliability-reviewer, migration-safety-reviewer), Sonnet (test-author, feature-implementer, ui-test-author, docs-writer, pr-author, prototype-builder, debug-investigator, observability-reviewer, performance-reviewer, ops-readiness-reviewer, accessibility-reviewer), and Haiku (refactorer, plugin-validator). Post-green reviews fan out in parallel — two always-on (security, docs) plus six gated production-readiness reviewers (observability, reliability, performance, ops-readiness, migration-safety, accessibility) that fire only when their trigger matches the diff. Rook (pr-author) closes the quest with a platform-agnostic PR draft and folds the runbook into the body. Integrates with IDD-framework specs.",
   "author": { "name": "GrillerGeek" },
   "homepage": "https://github.com/GrillerGeek/guildhall",

--- a/plugin/agents/model-echo.md
+++ b/plugin/agents/model-echo.md
@@ -8,10 +8,12 @@ tools: ["Bash"]
 
 You are the model-echo diagnostic probe. You are not an adventurer. You have no character voice and no quest mission beyond reporting.
 
+Your ENTIRE reply is a single line of the form `model: <string>` — the first characters you emit are `model: `. Anything before or after that line (a preamble, a "Based on..." sentence, an explanation of how you determined it) is a contract violation, even if it seems helpful.
+
 ## Your contract
 
 - **INPUT:** a one-line greeting from Mordain (e.g., "Report the model you are running on."). You do not need to parse it — your job is fixed regardless of the greeting text.
-- **OUTPUT:** exactly one line on stdout, of the form `model: <string>`. Nothing else. No preamble, no explanation, no closing remarks.
+- **OUTPUT:** a line of the form `model: <string>`. Ideally your reply is exactly that one line and nothing else — no preamble, no explanation, no closing remarks. Whatever else happens, your reply MUST end with that `model: ` line; the final line is the contract Mordain parses.
 
 ## How to determine the model string
 
@@ -22,7 +24,9 @@ Try these in order until you have a non-empty answer:
 
 ## Hard rules
 
-- Return exactly one line. The line MUST start with `model: ` (literal, including the space after the colon).
+- Your reply MUST end with a line starting `model: ` (literal, including the space after the colon). Aim for that being your only line.
+- If `$ANTHROPIC_MODEL` is empty, do NOT say so — emit nothing about the fallback. Go straight to introspection and output only the single `model: <string>` line.
+- No preamble of any kind. Your reply's first characters are `model: `. Never describe how you determined the answer.
 - Do NOT explain your reasoning.
 - Do NOT run any Bash command other than `echo "$ANTHROPIC_MODEL"`. (Self-introspection requires no command at all and remains allowed per the fallback above.)
 - Do NOT write any file.

--- a/plugin/commands/quest.md
+++ b/plugin/commands/quest.md
@@ -90,9 +90,9 @@ If the quest didn't qualify for the docs fast lane, pick a mode explicitly befor
 
 Before producing the plan, dispatch the `model-echo` diagnostic to verify that the explicit-model-parameter workaround is functioning. This is a one-shot diagnostic, not a blocking gate.
 
-1. Locate the `model-echo` agent file with `Glob("**/agents/model-echo.md")` (the plugin may be installed at an arbitrary path — do NOT hardcode `plugin/agents/`). Read the match's frontmatter and confirm `model: sonnet`.
+1. `model-echo`'s tier is `sonnet`, per the roster table above. The table is a validator-enforced mirror of the agent frontmatter (plugin-validator check 8), so you do NOT need to locate and read the agent file first.
 2. Dispatch with the model passed explicitly: `Agent(subagent_type: "model-echo", model: "sonnet", description: "Verify model routing", prompt: "Report the model you are running on.")`. The explicit `model` parameter is REQUIRED — Claude Code's subagent dispatch does not honor the agent file's frontmatter `model:` directly; only the explicit parameter works (see Step 4 for the full rationale).
-3. Read the response. An honest reply will contain `sonnet` or a Sonnet model ID such as `claude-sonnet-4-6`.
+3. Read the response's `model:` line — by contract the final line of the reply (smaller models sometimes preface it with narration; ignore everything before the `model:` line). An honest reply will name `sonnet` or a Sonnet model ID such as `claude-sonnet-4-6`.
 4. If the response names any model other than Sonnet (case-insensitive — `opus`, `fable`, `haiku`, or a non-Sonnet model ID), emit the following warning to the user (substituting the reported model) and then continue to Step 3:
 
    > ⚠️ Model-routing self-check: `model-echo` was dispatched with explicit `model: "sonnet"` parameter, but reported running on `<reported model>`. The dispatch parameter is not being honored. Likely causes: an `ANTHROPIC_MODEL` override set in your environment, a plan-level model constraint, or a deeper Claude Code issue. This quest will continue, but the cost posture documented in the README is compromised — investigate before trusting quest cost estimates.
@@ -126,7 +126,7 @@ Before dispatching adventurers, produce an implementation plan. This is the desi
 
    Record your selection — and your reasoning for any reviewer you skipped — in the plan file's `## Reviewers selected` section. The decision must be auditable.
 8. **Note the handoff context** each adventurer will need — you will pass this in the `prompt` field of their `Agent` dispatch, structured as **Mordain's brief** (below).
-9. **Read each adventurer's model.** For each adventurer in your sequence (including `model-echo` if not already cached, AND each gated reviewer you selected in Step 7), locate its agent file with `Glob("**/agents/<name>.md")` and Read the match to capture the `model:` value from its frontmatter. Cache per-adventurer for this quest. You will pass this value as the `model` parameter on the `Agent` dispatch call in Step 4 — this is REQUIRED, not optional.
+9. **Resolve each adventurer's model from the roster table.** For each adventurer in your sequence (AND each gated reviewer you selected in Step 7), take the `Tier` value from the roster table in this scroll. The table is a validator-enforced mirror of the agent frontmatter (plugin-validator check 8 fails the build when they drift), so it is trustworthy at dispatch time — no per-quest file reads needed. ONLY if an agent is missing from the table (e.g., a newly added adventurer), locate its file with `Glob("**/agents/<name>.md")` and Read the frontmatter `model:` — and flag the missing row in your report. You will pass the resolved value as the `model` parameter on the `Agent` dispatch call in Step 4 — this is REQUIRED, not optional.
 10. **Write the plan file.** At `docs/guildhall/plans/YYYY-MM-DD-<slug>.md`, following the template below. Commit mentally to this artifact being the canonical record of the quest. Mirror the same structure as a `TodoWrite` checklist for the live session UI.
 
 #### Mordain's brief — the dispatch prompt template
@@ -207,7 +207,7 @@ Dispatch via:
 ```
 Agent(
   subagent_type: <adventurer-agent-type>,
-  model: <alias from that adventurer's frontmatter, one of "sonnet" | "opus" | "haiku">,
+  model: <alias resolved in Step 3.9 (roster table), one of "sonnet" | "opus" | "haiku">,
   description: <short description of the dispatch>,
   prompt: <full handoff context — see template below>
 )
@@ -224,7 +224,7 @@ Agent(
 )
 ```
 
-**The `model` parameter is REQUIRED.** Older Claude Code versions do not honor the `model:` field in the agent file's frontmatter directly — if you omit the dispatch parameter there, the adventurer inherits your parent model (typically Opus 4.8) and the plugin's cost posture is invalidated. The `model` parameter at dispatch time is the mechanism that makes the frontmatter declaration take effect. You read each adventurer's model in Step 3; pass its literal string value (not a placeholder) here.
+**The `model` parameter is REQUIRED.** Older Claude Code versions do not honor the `model:` field in the agent file's frontmatter directly — if you omit the dispatch parameter there, the adventurer inherits your parent model (typically Opus 4.8) and the plugin's cost posture is invalidated. The `model` parameter at dispatch time is the mechanism that makes the frontmatter declaration take effect everywhere. You resolved each adventurer's model in Step 3.9; pass its literal string value (not a placeholder) here.
 
 #### Dispatch sequence per mode
 


### PR DESCRIPTION
## Summary

PR 4 of 4 in the [model-refresh design](docs/superpowers/specs/2026-06-10-model-refresh-design.md) — scoped strictly from friction the first three PRs surfaced.

- **Routing simplification (the PR 1 re-verification payoff):** Mordain resolves adventurer tiers from the quest.md roster table — trustworthy because plugin-validator check 8 enforces it as a mirror of the canonical frontmatter — eliminating N Glob+Read roundtrips per quest. The explicit `model` dispatch param is **retained** (decision recorded: older Claude Code installs still need it; cost posture depends on routing).
- **model-echo contract made robust:** Haiku narrates despite two rounds of prompt hardening (each round changed behavior — proving agent files are read at dispatch time). Rather than whack-a-mole, the contract is now "reply ends with the `model:` line" and Mordain parses that line.
- **Dogfood protocol documented in CLAUDE.md:** command/skill content is snapshotted at session start, so quest.md changes need a fresh session to exercise; agent files don't.

Skipped (no observed friction): post-green batching, token-budget awareness, chronicle changes.

## Test plan

- [x] Tabs (`plugin-validator`, Haiku): 0 errors, 0 warnings on the full 8-check set
- [x] model-echo live-dispatched on sonnet (production self-check path): exactly one line, contract satisfied
- [x] model-echo live-dispatched on haiku: narrates but ends with the `model:` line — new parse contract satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)