### PR TITLE
fix(quest): plugin-namespaced agent types on dispatch (v0.6.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-Guildhall is a **Claude Code plugin** — markdown-only. As of v0.6.1 it ships one slash command (`/quest`) and 18 agent definitions (17 adventurers tiered across Opus / Sonnet / Haiku, plus the `model-echo` diagnostic). There is no application code, no build step, no test suite, no linter. "Running" the plugin means installing it into Claude Code and issuing `/quest`; "testing" a change means dogfooding a quest against a real task — **from a freshly started session**: Claude Code snapshots command/skill content at session start, so a `/quest` issued in the session that edited `quest.md` exercises the stale snapshot, not your change (verified 2026-06-10). Agent files are read at dispatch time and don't have this constraint.
+Guildhall is a **Claude Code plugin** — markdown-only. As of v0.6.2 it ships one slash command (`/quest`) and 18 agent definitions (17 adventurers tiered across Opus / Sonnet / Haiku, plus the `model-echo` diagnostic). There is no application code, no build step, no test suite, no linter. "Running" the plugin means installing it into Claude Code and issuing `/quest`; "testing" a change means dogfooding a quest against a real task — **from a freshly started session**: Claude Code snapshots command/skill content at session start, so a `/quest` issued in the session that edited `quest.md` exercises the stale snapshot, not your change (verified 2026-06-10). Agent files are read at dispatch time and don't have this constraint.
 
 Install for local development:
 

--- a/docs/superpowers/specs/2026-06-10-model-refresh-design.md
+++ b/docs/superpowers/specs/2026-06-10-model-refresh-design.md
@@ -86,3 +86,15 @@ Parent session model: Fable 5. Agent under test: `model-echo` (frontmatter `mode
 The upstream issue that motivated the explicit-param workaround appears fixed in current Claude Code. Per this design's pre-commitment, no routing redesign happens in PR 1: the workaround stays as belt-and-braces (older Claude Code versions in the field still need it). **PR 4 candidate:** decide whether to retire the workaround — which would simplify `quest.md` Steps 2, 3.9, and 4.
 
 Incidental observation: in test B, model-echo (on Haiku) prepended an explanatory line, violating its own "exactly one line" hard rule. Minor; candidate for PR 4 prompt-hardening.
+
+## Appendix 2 — fresh-session dogfood verification (2026-06-10, post-merge)
+
+Full feature-mode quest run by Jason from a freshly started **Claude Fable 5** session against a scratch project (`/tmp/guildhall-dogfood`, slugify spec with 5 Expectations). Results:
+
+- `parent_model: "claude-fable-5"` populated in plan frontmatter — Step 2.7 works; the recommended Fable seat was exercised.
+- Roster-table tier resolution confirmed: plan lists `refactorer (haiku)` — the fresh snapshot ran v0.6.1 quest.md, not a stale cache.
+- TDD gates held: expected-RED via the ModuleNotFoundError carve-out → GREEN 10/10 → green after docs. Tink conditionally skipped with reason; Aldric skipped (routine work).
+- Gating textbook: Vance fired (default-on), five reviewers skipped with auditable reasons, Vera/Lior pair-skip correct. Oriana med/low findings → Open items. IDD tech-lead closing gate ran.
+- Chronicle claims were evidence-grounded ("all verifications run by Mordain via pytest").
+
+**Bug found and fixed (v0.6.2):** bare `subagent_type: "model-echo"` failed to resolve; the plugin-namespaced `guildhall:model-echo` worked. quest.md now uses namespaced agent types on all dispatches, with a bare-name retry note for older Claude Code. The model-refresh roadmap is fully verified and closed.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "guildhall",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "The Guildhall — a gathering place for adventurers. A TDD-ordered coding agent harness for Claude Code, tuned for Opus 4.8. The /quest slash command runs Mordain the Guildmaster, who writes a durable plan file, then dispatches 17 specialist adventurers across three tiers: Opus (architecture-reviewer, security-reviewer, reliability-reviewer, migration-safety-reviewer), Sonnet (test-author, feature-implementer, ui-test-author, docs-writer, pr-author, prototype-builder, debug-investigator, observability-reviewer, performance-reviewer, ops-readiness-reviewer, accessibility-reviewer), and Haiku (refactorer, plugin-validator). Post-green reviews fan out in parallel — two always-on (security, docs) plus six gated production-readiness reviewers (observability, reliability, performance, ops-readiness, migration-safety, accessibility) that fire only when their trigger matches the diff. Rook (pr-author) closes the quest with a platform-agnostic PR draft and folds the runbook into the body. Integrates with IDD-framework specs.",
   "author": { "name": "GrillerGeek" },
   "homepage": "https://github.com/GrillerGeek/guildhall",

--- a/plugin/commands/quest.md
+++ b/plugin/commands/quest.md
@@ -91,7 +91,7 @@ If the quest didn't qualify for the docs fast lane, pick a mode explicitly befor
 Before producing the plan, dispatch the `model-echo` diagnostic to verify that the explicit-model-parameter workaround is functioning. This is a one-shot diagnostic, not a blocking gate.
 
 1. `model-echo`'s tier is `sonnet`, per the roster table above. The table is a validator-enforced mirror of the agent frontmatter (plugin-validator check 8), so you do NOT need to locate and read the agent file first.
-2. Dispatch with the model passed explicitly: `Agent(subagent_type: "model-echo", model: "sonnet", description: "Verify model routing", prompt: "Report the model you are running on.")`. The explicit `model` parameter is REQUIRED — Claude Code's subagent dispatch does not honor the agent file's frontmatter `model:` directly; only the explicit parameter works (see Step 4 for the full rationale).
+2. Dispatch with the model passed explicitly: `Agent(subagent_type: "guildhall:model-echo", model: "sonnet", description: "Verify model routing", prompt: "Report the model you are running on.")`. Plugin agents resolve under their `guildhall:` namespace (see the namespace note in Step 4). The explicit `model` parameter is REQUIRED — Claude Code's subagent dispatch does not honor the agent file's frontmatter `model:` directly; only the explicit parameter works (see Step 4 for the full rationale).
 3. Read the response's `model:` line — by contract the final line of the reply (smaller models sometimes preface it with narration; ignore everything before the `model:` line). An honest reply will name `sonnet` or a Sonnet model ID such as `claude-sonnet-4-6`.
 4. If the response names any model other than Sonnet (case-insensitive — `opus`, `fable`, `haiku`, or a non-Sonnet model ID), emit the following warning to the user (substituting the reported model) and then continue to Step 3:
 
@@ -213,11 +213,13 @@ Agent(
 )
 ```
 
+**Agent-type namespace:** plugin-provided agents resolve under their plugin-namespaced form — `guildhall:<agent-type>` (e.g., `guildhall:test-author`). Use the namespaced form on every dispatch. If a namespaced dispatch fails to resolve (older Claude Code), retry once with the bare name — a name-resolution miss is not a routing failure and does not warrant the Step 2 warning.
+
 Concrete filled example (Seraphine, `test-author`, model `sonnet`):
 
 ```
 Agent(
-  subagent_type: "test-author",
+  subagent_type: "guildhall:test-author",
   model: "sonnet",
   description: "Write failing tests from reservations spec",
   prompt: "You are Seraphine Dawnveil, the test-author. === MISSION === ..."


### PR DESCRIPTION
## Summary

Found by the fresh-session dogfood quest (run from a Fable 5 session against a scratch slugify spec): Mordain's first dispatch on the bare `subagent_type: \"model-echo\"` failed to resolve — the plugin-namespaced `guildhall:model-echo` is what works. quest.md now uses namespaced agent types in both dispatch examples, with a documented bare-name retry for older Claude Code (a resolution miss is not a routing failure).

Also records the full dogfood verification in the design doc's appendix 2 — every v0.6.1 behavior confirmed in the wild: `parent_model` populated, roster-table tier resolution (plan said `refactorer (haiku)`), all TDD gates held, textbook reviewer gating.

## Test plan

- [x] Tabs (`plugin-validator`, Haiku): 0 errors, 0 warnings
- [x] The fix mirrors exactly what the live quest proved works (`guildhall:`-namespaced dispatch succeeded; bare name failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)