### PR TITLE
feat(implementer): mark deliberate shortcuts with minimal: comments (v0.6.3)

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "guildhall",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "The Guildhall — a gathering place for adventurers. A TDD-ordered coding agent harness for Claude Code, tuned for Opus 4.8. The /quest slash command runs Mordain the Guildmaster, who writes a durable plan file, then dispatches 17 specialist adventurers across three tiers: Opus (architecture-reviewer, security-reviewer, reliability-reviewer, migration-safety-reviewer), Sonnet (test-author, feature-implementer, ui-test-author, docs-writer, pr-author, prototype-builder, debug-investigator, observability-reviewer, performance-reviewer, ops-readiness-reviewer, accessibility-reviewer), and Haiku (refactorer, plugin-validator). Post-green reviews fan out in parallel — two always-on (security, docs) plus six gated production-readiness reviewers (observability, reliability, performance, ops-readiness, migration-safety, accessibility) that fire only when their trigger matches the diff. Rook (pr-author) closes the quest with a platform-agnostic PR draft and folds the runbook into the body. Integrates with IDD-framework specs.",
   "author": { "name": "GrillerGeek" },
   "homepage": "https://github.com/GrillerGeek/guildhall",

--- a/plugin/agents/feature-implementer.md
+++ b/plugin/agents/feature-implementer.md
@@ -41,3 +41,5 @@ You are **Bruga Ironseam** — a dwarven Artificer who works from the blueprint 
 - Do NOT expand the feature beyond what Expectations specify.
 
 **Hard rule:** if the spec is missing one of the mandatory blocks, drop the hammer and return to Mordain. A smith does not forge from a blank page.
+
+**Hard rule — mark the rough joins.** When you deliberately leave a join rough — a shortcut with a known ceiling (a global lock, an O(n²) scan over a small list, a naive heuristic) — name it in a `minimal:` comment that states the ceiling and the upgrade path: `# minimal: global lock; per-account locks if throughput matters`. You forge minimal by contract, so the reviewers who follow must be able to read a simplification as a smith's deliberate choice, not a crack you missed. A rough join left unmarked is an unfinished one. This is never licence to mark away a guard the Expectations or Boundaries require — those are forged in full.


### PR DESCRIPTION
## What

Adds one Hard rule to `feature-implementer` (Bruga Ironseam): when it deliberately leaves a shortcut with a known ceiling (a global lock, an O(n²) scan over a small list, a naive heuristic), name it in a `minimal:` comment that states the ceiling and the upgrade path — e.g. `# minimal: global lock; per-account locks if throughput matters`. So the downstream reviewers read a simplification as a smith's deliberate choice, not a crack he missed. Never licence to mark away a guard the Expectations or Boundaries require.

Bumps `plugin.json` 0.6.2 → 0.6.3 (patch).

## Why — this is the one portable idea from a measured Ponytail assessment

The starting question was whether Guildhall should adopt the [Ponytail](https://github.com/DietrichGebert/ponytail) plugin's "lazy senior dev" YAGNI ladder (stdlib > native feature > installed dep > one line > minimum) to build faster with fewer tokens.

I ran a scoped A/B (no harness): dispatched `guildhall:feature-implementer` on three tasks (date field, count endpoint, caching) across **Sonnet and Haiku**, control vs. a ladder-augmented prompt, scored by `git diff` added lines.

**Result: measured null.** Every control arm was already lazy — native `<input type="date">`, a single `func.count()` query, `lru_cache` — including on Ponytail's flagship caching trap, including on Haiku (the tier where Ponytail's −94% wins live). The ladder added zero reduction.

| task | tier | control | +ladder |
|---|---|--:|--:|
| date-of-birth field | Sonnet | +6 | +6 (byte-identical) |
| count user's items | Sonnet | +7 | +7 |
| caching (Ponytail's trap) | Sonnet | +4 | +3 |
| caching | Haiku | +3 | +3 |

**Why:** Guildhall already captures Ponytail's effect at the architecture layer — the specialist-contract design (`feature-implementer` = constrained TDD implementer, "nothing more, nothing less") is the same forcing function Ponytail injects at the prompt layer. Ponytail's large gains come from a *naked* agent free to over-build; Guildhall has no such agent.

## What was rejected (and why that's the point)

- **Minimalism ladder in `feature-implementer`** — dropped. Measured null; would be inert prompt-bloat on every dispatch.
- **Gated `simplicity-reviewer`** — dropped. If agents don't over-build, the reviewer mostly returns "Lean already. Ship." — itself the kind of speculative addition YAGNI rejects.
- **`minimal:` comment convention** — kept (this PR). Near-zero cost, no new agent or dispatch, improves auditability of the simplifications the implementer already makes.

## Scope / safety

- Single agent prose addition; no frontmatter, tools, or tier change → `plugin-validator` check 8 (cross-file tier consistency) unaffected.
- Voice preserved (Bruga's smith metaphor).
- Agent files are read at dispatch time, so this is live immediately — no fresh-session snapshot caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)